### PR TITLE
Bugfix/deprecation warnings

### DIFF
--- a/common/reactive-grpc-common/src/test/java/com/salesforce/reactivegrpccommon/CancellableStreamObserverTest.java
+++ b/common/reactive-grpc-common/src/test/java/com/salesforce/reactivegrpccommon/CancellableStreamObserverTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 
-@SuppressWarnings("ALL")
+@SuppressWarnings("unchecked")
 public class CancellableStreamObserverTest {
     @Test
     public void statusExceptionTriggersHandler() {

--- a/common/reactive-grpc-gencommon/src/main/java/com/salesforce/reactivegrpcgencommon/ReactiveGrpcGenerator.java
+++ b/common/reactive-grpc-gencommon/src/main/java/com/salesforce/reactivegrpcgencommon/ReactiveGrpcGenerator.java
@@ -226,5 +226,9 @@ public abstract class ReactiveGrpcGenerator extends Generator {
             }
             return s.toString();
         }
+
+        public String methodNamePascalCase() {
+            return String.valueOf(Character.toUpperCase(methodName.charAt(0))) + methodName.substring(1);
+        }
     }
 }

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/CancellationPropagationIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/CancellationPropagationIntegrationTest.java
@@ -28,7 +28,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("ALL")
+@SuppressWarnings({"unchecked", "Duplicates"})
 public class CancellationPropagationIntegrationTest {
     private static final int NUMBER_OF_STREAM_ELEMENTS = 10000;
     private static final int SEQUENCE_DELAY_MILLIS = 10;

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ConcurrentRequestIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ConcurrentRequestIntegrationTest.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("Duplicates")
+@SuppressWarnings({"Duplicates", "unchecked"})
 public class ConcurrentRequestIntegrationTest {
     private static Server server;
     private static ManagedChannel channel;

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ServerErrorIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ServerErrorIntegrationTest.java
@@ -18,7 +18,7 @@ import reactor.test.StepVerifier;
 
 import java.time.Duration;
 
-@SuppressWarnings("ALL")
+@SuppressWarnings("unchecked")
 public class ServerErrorIntegrationTest {
     private static Server server;
     private static ManagedChannel channel;
@@ -79,7 +79,7 @@ public class ServerErrorIntegrationTest {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
         Flux<HelloResponse> resp = stub.sayHelloRespStream(Mono.just(HelloRequest.getDefaultInstance()));
         Flux<HelloResponse> test = resp
-                .doOnNext(msg -> System.out.println(msg))
+                .doOnNext(System.out::println)
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
                 .doOnComplete(() -> System.out.println("Completed"))
                 .doOnCancel(() -> System.out.println("Client canceled"));

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/UnexpectedServerErrorIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/UnexpectedServerErrorIntegrationTest.java
@@ -19,7 +19,7 @@ import reactor.test.StepVerifier;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-@SuppressWarnings("ALL")
+@SuppressWarnings("unchecked")
 public class UnexpectedServerErrorIntegrationTest {
     private static Server server;
     private static ManagedChannel channel;
@@ -84,7 +84,7 @@ public class UnexpectedServerErrorIntegrationTest {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
         Flux<HelloResponse> resp = stub.sayHelloRespStream(Mono.just(HelloRequest.getDefaultInstance()));
         Flux<HelloResponse> test = resp
-                .doOnNext(msg -> System.out.println(msg))
+                .doOnNext(System.out::println)
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
                 .doOnComplete(() -> System.out.println("Completed"))
                 .doOnCancel(() -> System.out.println("Client canceled"));

--- a/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
+++ b/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
@@ -67,7 +67,7 @@ public final class {{className}} {
             return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
                     {{#methods}}
                     .addMethod(
-                            {{packageName}}.{{serviceName}}Grpc.METHOD_{{methodNameUpperUnderscore}},
+                            {{packageName}}.{{serviceName}}Grpc.get{{methodNamePascalCase}}Method(),
                             {{grpcCallsMethodName}}(
                                     new MethodHandlers<
                                             {{inputType}},

--- a/rx-java/rxgrpc-stub/src/test/java/com/salesforce/rxgrpc/stub/SubscribeOnlyOnceTest.java
+++ b/rx-java/rxgrpc-stub/src/test/java/com/salesforce/rxgrpc/stub/SubscribeOnlyOnceTest.java
@@ -17,6 +17,7 @@ import org.reactivestreams.Subscription;
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.*;
 
+@SuppressWarnings("unchecked")
 public class SubscribeOnlyOnceTest {
     @Test
     public void subscribeOnlyOnceFlowableOperatorErrorsWhenMultipleSubscribe() {

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/CancellationPropagationIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/CancellationPropagationIntegrationTest.java
@@ -29,7 +29,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("ALL")
+@SuppressWarnings({"unchecked", "Duplicates"})
 public class CancellationPropagationIntegrationTest {
     private static final int NUMBER_OF_STREAM_ELEMENTS = 10000;
 

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ServerErrorIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ServerErrorIntegrationTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-@SuppressWarnings("ALL")
+@SuppressWarnings("unchecked")
 public class ServerErrorIntegrationTest {
     private static Server server;
     private static ManagedChannel channel;
@@ -76,7 +76,7 @@ public class ServerErrorIntegrationTest {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Flowable<HelloResponse> resp = stub.sayHelloRespStream(Single.just(HelloRequest.getDefaultInstance()));
         TestSubscriber<HelloResponse> test = resp
-                .doOnNext(msg -> System.out.println(msg))
+                .doOnNext(System.out::println)
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
                 .doOnComplete(() -> System.out.println("Completed"))
                 .doOnCancel(() -> System.out.println("Client canceled"))

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/UnexpectedServerErrorIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/UnexpectedServerErrorIntegrationTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-@SuppressWarnings("ALL")
+@SuppressWarnings("unchecked")
 public class UnexpectedServerErrorIntegrationTest {
     private static Server server;
     private static ManagedChannel channel;

--- a/rx-java/rxgrpc/src/main/resources/RxStub.mustache
+++ b/rx-java/rxgrpc/src/main/resources/RxStub.mustache
@@ -67,7 +67,7 @@ public final class {{className}} {
             return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
                     {{#methods}}
                     .addMethod(
-                            {{packageName}}.{{serviceName}}Grpc.METHOD_{{methodNameUpperUnderscore}},
+                            {{packageName}}.{{serviceName}}Grpc.get{{methodNamePascalCase}}Method(),
                             {{grpcCallsMethodName}}(
                                     new MethodHandlers<
                                             {{inputType}},


### PR DESCRIPTION
Fixes #41 

* Fix deprecated deprecation warnings in generated stubs introduced with gRPC 1.9
* Fix misc. compilation warnings from tests