### PR TITLE
Use the defer operator to wrap a gRPC stream creation

### DIFF
--- a/demos/reactive-grpc-examples/src/main/java/com/salesforce/reactivegrpc/examples/ResumeStreamReactorDemo.java
+++ b/demos/reactive-grpc-examples/src/main/java/com/salesforce/reactivegrpc/examples/ResumeStreamReactorDemo.java
@@ -66,14 +66,14 @@ public final class ResumeStreamReactorDemo {
     }
 
     /**
-     * GrpcRetryFlux automatically restarts a gRPC Flowable stream in the face of an error.
+     * GrpcRetryFlux automatically restarts a gRPC Flux stream in the face of an error.
      * @param <T>
      */
     private static class GrpcRetryFlux<T> extends Flux<T> {
         private final Flux<T> retryFlux;
 
         GrpcRetryFlux(Supplier<Flux<T>> fluxSupplier) {
-            this.retryFlux = Flux.<T>create(sink -> fluxSupplier.get().subscribe(sink::next, sink::error, sink::complete)).retry();
+            this.retryFlux = Flux.defer(fluxSupplier::get).retry();
         }
 
         @Override

--- a/demos/reactive-grpc-examples/src/main/java/com/salesforce/reactivegrpc/examples/ResumeStreamRxJavaDemo.java
+++ b/demos/reactive-grpc-examples/src/main/java/com/salesforce/reactivegrpc/examples/ResumeStreamRxJavaDemo.java
@@ -13,7 +13,6 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 import java.util.concurrent.ThreadLocalRandom;
@@ -74,8 +73,7 @@ public final class ResumeStreamRxJavaDemo {
         private final Flowable<T> retryFlowable;
 
         GrpcRetryFlowable(Supplier<Flowable<T>> flowableSupplier) {
-            this.retryFlowable = Flowable.unsafeCreate(
-                    (Publisher<T>) subscriber -> flowableSupplier.get().subscribe(subscriber)).retry();
+            this.retryFlowable = Flowable.defer(flowableSupplier::get).retry();
         }
 
         @Override


### PR DESCRIPTION
This has the advantage to allow a retry, and will also automatically unsubscribe from the original stream when the subscription is cancelled