### PR TITLE
Feature/abstract stub

### DIFF
--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/AbstractStubTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/AbstractStubTest.java
@@ -1,0 +1,30 @@
+package com.salesforce.reactorgrpc;
+
+import io.grpc.Deadline;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractStubTest {
+    @Test
+    public void getChannelWorks() {
+        ManagedChannel channel = InProcessChannelBuilder.forName("settingCallOptionsWorks").build();
+        ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
+
+        assertThat(stub.getChannel()).isEqualTo(channel);
+    }
+
+    @Test
+    public void settingCallOptionsWorks() {
+        ManagedChannel channel = InProcessChannelBuilder.forName("settingCallOptionsWorks").build();
+        Deadline deadline = Deadline.after(42, TimeUnit.SECONDS);
+
+        ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel).withDeadline(deadline);
+
+        assertThat(stub.getCallOptions().getDeadline()).isEqualTo(deadline);
+    }
+}

--- a/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
+++ b/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
@@ -25,11 +25,22 @@ public final class {{className}} {
     {{#javaDoc}}
     {{{javaDoc}}}
     {{/javaDoc}}
-    public static final class Reactor{{serviceName}}Stub {
+    public static final class Reactor{{serviceName}}Stub extends io.grpc.stub.AbstractStub<Reactor{{serviceName}}Stub> {
         private {{serviceName}}Grpc.{{serviceName}}Stub delegateStub;
 
         private Reactor{{serviceName}}Stub(io.grpc.Channel channel) {
+            super(channel);
             delegateStub = {{serviceName}}Grpc.newStub(channel);
+        }
+
+        private Reactor{{serviceName}}Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            super(channel);
+            delegateStub = {{serviceName}}Grpc.newStub(channel).build(channel, callOptions);
+        }
+
+        @Override
+        protected Reactor{{serviceName}}Stub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new Reactor{{serviceName}}Stub(channel, callOptions);
         }
 
         {{#methods}}

--- a/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
+++ b/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
@@ -34,7 +34,7 @@ public final class {{className}} {
         }
 
         private Reactor{{serviceName}}Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-            super(channel);
+            super(channel, callOptions);
             delegateStub = {{serviceName}}Grpc.newStub(channel).build(channel, callOptions);
         }
 

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/AbstractStubTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/AbstractStubTest.java
@@ -1,0 +1,30 @@
+package com.salesforce.rxgrpc;
+
+import io.grpc.Deadline;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractStubTest {
+    @Test
+    public void getChannelWorks() {
+        ManagedChannel channel = InProcessChannelBuilder.forName("settingCallOptionsWorks").build();
+        RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
+
+        assertThat(stub.getChannel()).isEqualTo(channel);
+    }
+
+    @Test
+    public void settingCallOptionsWorks() {
+        ManagedChannel channel = InProcessChannelBuilder.forName("settingCallOptionsWorks").build();
+        Deadline deadline = Deadline.after(42, TimeUnit.SECONDS);
+
+        RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel).withDeadline(deadline);
+
+        assertThat(stub.getCallOptions().getDeadline()).isEqualTo(deadline);
+    }
+}

--- a/rx-java/rxgrpc/src/main/resources/RxStub.mustache
+++ b/rx-java/rxgrpc/src/main/resources/RxStub.mustache
@@ -34,7 +34,7 @@ public final class {{className}} {
         }
 
         private Rx{{serviceName}}Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-            super(channel);
+            super(channel, callOptions);
             delegateStub = {{serviceName}}Grpc.newStub(channel).build(channel, callOptions);
         }
 

--- a/rx-java/rxgrpc/src/main/resources/RxStub.mustache
+++ b/rx-java/rxgrpc/src/main/resources/RxStub.mustache
@@ -25,11 +25,22 @@ public final class {{className}} {
     {{#javaDoc}}
     {{{javaDoc}}}
     {{/javaDoc}}
-    public static final class Rx{{serviceName}}Stub {
+    public static final class Rx{{serviceName}}Stub extends io.grpc.stub.AbstractStub<Rx{{serviceName}}Stub> {
         private {{serviceName}}Grpc.{{serviceName}}Stub delegateStub;
 
         private Rx{{serviceName}}Stub(io.grpc.Channel channel) {
+            super(channel);
             delegateStub = {{serviceName}}Grpc.newStub(channel);
+        }
+
+        private Rx{{serviceName}}Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            super(channel);
+            delegateStub = {{serviceName}}Grpc.newStub(channel).build(channel, callOptions);
+        }
+
+        @Override
+        protected Rx{{serviceName}}Stub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new Rx{{serviceName}}Stub(channel, callOptions);
         }
 
         {{#methods}}


### PR DESCRIPTION
Fixes #50 

Generated client stubs now extend `AbstractStub<T>`, thereby gaining its powers.