### PR TITLE
Feature/upgrade rxjava

### DIFF
--- a/demos/RxChat/RxChat-Client/src/main/java/com/salesforce/servicelibs/ChatClient.java
+++ b/demos/RxChat/RxChat-Client/src/main/java/com/salesforce/servicelibs/ChatClient.java
@@ -39,10 +39,10 @@ public final class ChatClient {
         // Prompt the user for their name
         console.println("Press ctrl+D to quit");
         String author = console.readLine("Who are you? > ");
-        stub.postMessage(toMessage(author, author + " joined.")).subscribe();
+        toMessage(author, author + " joined.").compose(stub::postMessage).subscribe();
 
         // Subscribe to incoming messages
-        Disposable chatSubscription = stub.getMessages(Single.just(Empty.getDefaultInstance())).subscribe(
+        Disposable chatSubscription = Single.just(Empty.getDefaultInstance()).as(stub::getMessages).subscribe(
             message -> {
                 // Don't re-print our own messages
                 if (!message.getAuthor().equals(author)) {
@@ -71,7 +71,7 @@ public final class ChatClient {
 
         // Wait for a signal to exit, then clean up
         done.await();
-        stub.postMessage(toMessage(author, author + " left.")).subscribe();
+        toMessage(author, author + " left.").compose(stub::postMessage).subscribe();
         chatSubscription.dispose();
         channel.shutdown();
         channel.awaitTermination(1, TimeUnit.SECONDS);

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <protoc.version>3.5.1</protoc.version> <!-- Same version as grpc-proto -->
         <grpc.contrib.version>0.8.0</grpc.contrib.version>
 
+        <rxjava.version>2.1.10</rxjava.version>
         <reactor.version>3.1.5.RELEASE</reactor.version>
 
         <!-- Test Dependency Versions -->

--- a/reactor/reactor-grpc-tck/src/test/java/com/salesforce/reactorgrpc/tck/ReactorGrpcSubscriberWhiteboxVerificationTest.java
+++ b/reactor/reactor-grpc-tck/src/test/java/com/salesforce/reactorgrpc/tck/ReactorGrpcSubscriberWhiteboxVerificationTest.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
  * Subscriber tests from the Reactive Streams Technology Compatibility Kit.
  * https://github.com/reactive-streams/reactive-streams-jvm/tree/master/tck
  */
+@SuppressWarnings("Duplicates")
 public class ReactorGrpcSubscriberWhiteboxVerificationTest extends SubscriberWhiteboxVerification<Message> {
     public ReactorGrpcSubscriberWhiteboxVerificationTest() {
         super(new TestEnvironment());

--- a/rx-java/rxgrpc-stub/pom.xml
+++ b/rx-java/rxgrpc-stub/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
-            <version>2.1.0</version>
+            <version>${rxjava.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/rx-java/rxgrpc-tck/pom.xml
+++ b/rx-java/rxgrpc-tck/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams-tck</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcPublisherManyToManyVerificationTest.java
+++ b/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcPublisherManyToManyVerificationTest.java
@@ -56,7 +56,7 @@ public class RxGrpcPublisherManyToManyVerificationTest extends PublisherVerifica
     public Publisher<Message> createPublisher(long elements) {
         RxTckGrpc.RxTckStub stub = RxTckGrpc.newRxStub(channel);
         Flowable<Message> request = Flowable.range(0, (int)elements).map(this::toMessage);
-        Publisher<Message> publisher = stub.manyToMany(request);
+        Publisher<Message> publisher = request.compose(stub::manyToMany);
 
         return publisher;
     }
@@ -65,7 +65,7 @@ public class RxGrpcPublisherManyToManyVerificationTest extends PublisherVerifica
     public Publisher<Message> createFailedPublisher() {
         RxTckGrpc.RxTckStub stub = RxTckGrpc.newRxStub(channel);
         Flowable<Message> request = Flowable.just(toMessage(TckService.KABOOM));
-        Publisher<Message> publisher = stub.manyToMany(request);
+        Publisher<Message> publisher = request.compose(stub::manyToMany);
 
         return publisher;
     }

--- a/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcPublisherManyToOneVerificationTest.java
+++ b/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcPublisherManyToOneVerificationTest.java
@@ -62,7 +62,7 @@ public class RxGrpcPublisherManyToOneVerificationTest extends PublisherVerificat
     public Publisher<Message> createPublisher(long elements) {
         RxTckGrpc.RxTckStub stub = RxTckGrpc.newRxStub(channel);
         Flowable<Message> request = Flowable.range(0, (int)elements).map(this::toMessage);
-        Single<Message> publisher = stub.manyToOne(request);
+        Single<Message> publisher = request.as(stub::manyToOne);
 
         return publisher.toFlowable();
     }
@@ -71,7 +71,7 @@ public class RxGrpcPublisherManyToOneVerificationTest extends PublisherVerificat
     public Publisher<Message> createFailedPublisher() {
         RxTckGrpc.RxTckStub stub = RxTckGrpc.newRxStub(channel);
         Flowable<Message> request = Flowable.just(toMessage(TckService.KABOOM));
-        Single<Message> publisher = stub.manyToOne(request);
+        Single<Message> publisher = request.as(stub::manyToOne);
 
         return publisher.toFlowable();
     }

--- a/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcPublisherOneToManyVerificationTest.java
+++ b/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcPublisherOneToManyVerificationTest.java
@@ -56,7 +56,7 @@ public class RxGrpcPublisherOneToManyVerificationTest extends PublisherVerificat
     public Publisher<Message> createPublisher(long elements) {
         RxTckGrpc.RxTckStub stub = RxTckGrpc.newRxStub(channel);
         Single<Message> request = Single.just(toMessage((int) elements));
-        Publisher<Message> publisher = stub.oneToMany(request);
+        Publisher<Message> publisher = request.as(stub::oneToMany);
 
         return publisher;
     }
@@ -65,7 +65,7 @@ public class RxGrpcPublisherOneToManyVerificationTest extends PublisherVerificat
     public Publisher<Message> createFailedPublisher() {
         RxTckGrpc.RxTckStub stub = RxTckGrpc.newRxStub(channel);
         Single<Message> request = Single.just(toMessage(TckService.KABOOM));
-        Publisher<Message> publisher = stub.oneToMany(request);
+        Publisher<Message> publisher = request.as(stub::oneToMany);
 
         return publisher;
     }

--- a/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcPublisherOneToOneVerificationTest.java
+++ b/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcPublisherOneToOneVerificationTest.java
@@ -61,7 +61,7 @@ public class RxGrpcPublisherOneToOneVerificationTest extends PublisherVerificati
     public Publisher<Message> createPublisher(long elements) {
         RxTckGrpc.RxTckStub stub = RxTckGrpc.newRxStub(channel);
         Single<Message> request = Single.just(toMessage((int) elements));
-        Single<Message> publisher = stub.oneToOne(request);
+        Single<Message> publisher = request.compose(stub::oneToOne);
 
         return publisher.toFlowable();
     }
@@ -70,7 +70,7 @@ public class RxGrpcPublisherOneToOneVerificationTest extends PublisherVerificati
     public Publisher<Message> createFailedPublisher() {
         RxTckGrpc.RxTckStub stub = RxTckGrpc.newRxStub(channel);
         Single<Message> request = Single.just(toMessage(TckService.KABOOM));
-        Single<Message> publisher = stub.oneToOne(request);
+        Single<Message> publisher = request.compose(stub::oneToOne);
 
         return publisher.toFlowable();
     }

--- a/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcSubscriberWhiteboxVerificationTest.java
+++ b/rx-java/rxgrpc-tck/src/test/java/com/salesforce/rxgrpc/tck/RxGrpcSubscriberWhiteboxVerificationTest.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
  * Subscriber tests from the Reactive Streams Technology Compatibility Kit.
  * https://github.com/reactive-streams/reactive-streams-jvm/tree/master/tck
  */
+@SuppressWarnings("Duplicates")
 public class RxGrpcSubscriberWhiteboxVerificationTest extends SubscriberWhiteboxVerification<Message> {
     public RxGrpcSubscriberWhiteboxVerificationTest() {
         super(new TestEnvironment());

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/CancellationPropagationIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/CancellationPropagationIntegrationTest.java
@@ -42,21 +42,21 @@ public class CancellationPropagationIntegrationTest {
         private AtomicBoolean wasCanceled = new AtomicBoolean(false);
         private AtomicBoolean explicitCancel = new AtomicBoolean(false);
 
-        public void reset() {
+        void reset() {
             lastNumberProduced.set(Integer.MIN_VALUE);
             wasCanceled.set(false);
             explicitCancel.set(false);
         }
 
-        public int getLastNumberProduced() {
+        int getLastNumberProduced() {
             return lastNumberProduced.get();
         }
 
-        public boolean wasCanceled() {
+        boolean wasCanceled() {
             return wasCanceled.get();
         }
 
-        public void setExplicitCancel(boolean explicitCancel) {
+        void setExplicitCancel(boolean explicitCancel) {
             this.explicitCancel.set(explicitCancel);
         }
 
@@ -124,8 +124,8 @@ public class CancellationPropagationIntegrationTest {
     @Test
     public void clientCanCancelServerStreamExplicitly() throws InterruptedException {
         RxNumbersGrpc.RxNumbersStub stub = RxNumbersGrpc.newRxStub(channel);
-        TestSubscriber<NumberProto.Number> subscription = stub
-                .responsePressure(Single.just(Empty.getDefaultInstance()))
+        TestSubscriber<NumberProto.Number> subscription = Single.just(Empty.getDefaultInstance())
+                .as(stub::responsePressure)
                 .doOnNext(number -> System.out.println(number.getNumber(0)))
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
                 .doOnComplete(() -> System.out.println("Completed"))
@@ -145,8 +145,8 @@ public class CancellationPropagationIntegrationTest {
     @Test
     public void clientCanCancelServerStreamImplicitly() throws InterruptedException {
         RxNumbersGrpc.RxNumbersStub stub = RxNumbersGrpc.newRxStub(channel);
-        TestSubscriber<NumberProto.Number> subscription = stub
-                .responsePressure(Single.just(Empty.getDefaultInstance()))
+        TestSubscriber<NumberProto.Number> subscription =  Single.just(Empty.getDefaultInstance())
+                .as(stub::responsePressure)
                 .doOnNext(number -> System.out.println(number.getNumber(0)))
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
                 .doOnComplete(() -> System.out.println("Completed"))
@@ -186,8 +186,8 @@ public class CancellationPropagationIntegrationTest {
                     System.out.println("Client canceled");
                 });
 
-        TestObserver<NumberProto.Number> observer = stub
-                .requestPressure(request)
+        TestObserver<NumberProto.Number> observer = request
+                .as(stub::requestPressure)
                 .doOnSuccess(number -> System.out.println(number.getNumber(0)))
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
                 .test();
@@ -222,8 +222,8 @@ public class CancellationPropagationIntegrationTest {
                     System.out.println("Client canceled");
                 });
 
-        TestObserver<NumberProto.Number> observer = stub
-                .requestPressure(request)
+        TestObserver<NumberProto.Number> observer = request
+                .as(stub::requestPressure)
                 .doOnSuccess(number -> System.out.println(number.getNumber(0)))
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
                 .test();
@@ -257,8 +257,8 @@ public class CancellationPropagationIntegrationTest {
                     System.out.println("Client canceled");
                 });
 
-        TestSubscriber<NumberProto.Number> observer = stub
-                .twoWayPressure(request)
+        TestSubscriber<NumberProto.Number> observer = request
+                .compose(stub::twoWayPressure)
                 .doOnNext(number -> System.out.println(number.getNumber(0)))
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
                 .test();
@@ -291,8 +291,8 @@ public class CancellationPropagationIntegrationTest {
                     System.out.println("Client canceled");
                 });
 
-        TestSubscriber<NumberProto.Number> observer = stub
-                .twoWayPressure(request)
+        TestSubscriber<NumberProto.Number> observer = request
+                .compose(stub::twoWayPressure)
                 .doOnNext(number -> System.out.println(number.getNumber(0)))
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
                 .test();

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ClientThreadIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ClientThreadIntegrationTest.java
@@ -93,7 +93,7 @@ public class ClientThreadIntegrationTest {
     public void oneToOne() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Single<HelloRequest> req = Single.just(HelloRequest.newBuilder().setName("rxjava").build());
-        Single<HelloResponse> resp = stub.sayHello(req);
+        Single<HelloResponse> resp = req.compose(stub::sayHello);
 
         AtomicReference<String> clientThreadName = new AtomicReference<>();
 
@@ -119,7 +119,7 @@ public class ClientThreadIntegrationTest {
 
         AtomicReference<String> clientThreadName = new AtomicReference<>();
 
-        Flowable<HelloResponse> resp = stub.sayHelloBothStream(req);
+        Flowable<HelloResponse> resp = req.compose(stub::sayHelloBothStream);
 
         TestSubscriber<String> testSubscriber = resp
                 .map(HelloResponse::getMessage)

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ConcurrentRequestIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ConcurrentRequestIntegrationTest.java
@@ -104,11 +104,11 @@ public class ConcurrentRequestIntegrationTest {
         // == MAKE REQUESTS ==
         // One to One
         Single<HelloRequest> req1 = Single.just(HelloRequest.newBuilder().setName("rxjava").build());
-        Single<HelloResponse> resp1 = stub.sayHello(req1);
+        Single<HelloResponse> resp1 = req1.compose(stub::sayHello);
 
         // One to Many
         Single<HelloRequest> req2 = Single.just(HelloRequest.newBuilder().setName("rxjava").build());
-        Flowable<HelloResponse> resp2 = stub.sayHelloRespStream(req2);
+        Flowable<HelloResponse> resp2 = req2.as(stub::sayHelloRespStream);
 
         // Many to One
         Flowable<HelloRequest> req3 = Flowable.just(
@@ -116,7 +116,7 @@ public class ConcurrentRequestIntegrationTest {
                 HelloRequest.newBuilder().setName("b").build(),
                 HelloRequest.newBuilder().setName("c").build());
 
-        Single<HelloResponse> resp3 = stub.sayHelloReqStream(req3);
+        Single<HelloResponse> resp3 = req3.as(stub::sayHelloReqStream);
 
         // Many to Many
         Flowable<HelloRequest> req4 = Flowable.just(
@@ -126,7 +126,7 @@ public class ConcurrentRequestIntegrationTest {
                 HelloRequest.newBuilder().setName("d").build(),
                 HelloRequest.newBuilder().setName("e").build());
 
-        Flowable<HelloResponse> resp4 = stub.sayHelloBothStream(req4);
+        Flowable<HelloResponse> resp4 = req4.compose(stub::sayHelloBothStream);
 
         // == VERIFY RESPONSES ==
         ListeningExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/EndToEndIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/EndToEndIntegrationTest.java
@@ -84,10 +84,10 @@ public class EndToEndIntegrationTest {
     }
 
     @Test
-    public void oneToOne() throws IOException {
+    public void oneToOne() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Single<HelloRequest> req = Single.just(HelloRequest.newBuilder().setName("rxjava").build());
-        Single<HelloResponse> resp = stub.sayHello(req);
+        Single<HelloResponse> resp = req.compose(stub::sayHello);
 
         TestObserver<String> testObserver = resp.map(HelloResponse::getMessage).test();
         testObserver.awaitTerminalEvent(3, TimeUnit.SECONDS);
@@ -95,10 +95,10 @@ public class EndToEndIntegrationTest {
     }
 
     @Test
-    public void oneToMany() throws IOException {
+    public void oneToMany() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Single<HelloRequest> req = Single.just(HelloRequest.newBuilder().setName("rxjava").build());
-        Flowable<HelloResponse> resp = stub.sayHelloRespStream(req);
+        Flowable<HelloResponse> resp = req.as(stub::sayHelloRespStream);
 
         TestSubscriber<String> testSubscriber = resp.map(HelloResponse::getMessage).test();
         testSubscriber.awaitTerminalEvent(3, TimeUnit.SECONDS);
@@ -106,14 +106,14 @@ public class EndToEndIntegrationTest {
     }
 
     @Test
-    public void manyToOne() throws Exception {
+    public void manyToOne() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Flowable<HelloRequest> req = Flowable.just(
                 HelloRequest.newBuilder().setName("a").build(),
                 HelloRequest.newBuilder().setName("b").build(),
                 HelloRequest.newBuilder().setName("c").build());
 
-        Single<HelloResponse> resp = stub.sayHelloReqStream(req);
+        Single<HelloResponse> resp = req.as(stub::sayHelloReqStream);
 
         TestObserver<String> testObserver = resp.map(HelloResponse::getMessage).test();
         testObserver.awaitTerminalEvent(3, TimeUnit.SECONDS);
@@ -121,7 +121,7 @@ public class EndToEndIntegrationTest {
     }
 
     @Test
-    public void manyToMany() throws Exception {
+    public void manyToMany() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Flowable<HelloRequest> req = Flowable.just(
                 HelloRequest.newBuilder().setName("a").build(),
@@ -130,7 +130,7 @@ public class EndToEndIntegrationTest {
                 HelloRequest.newBuilder().setName("d").build(),
                 HelloRequest.newBuilder().setName("e").build());
 
-        Flowable<HelloResponse> resp = stub.sayHelloBothStream(req);
+        Flowable<HelloResponse> resp = req.compose(stub::sayHelloBothStream);
 
         TestSubscriber<String> testSubscriber = resp.map(HelloResponse::getMessage).test();
         testSubscriber.awaitTerminalEvent(3, TimeUnit.SECONDS);

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ReactiveClientStandardServerInteropTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ReactiveClientStandardServerInteropTest.java
@@ -117,7 +117,10 @@ public class ReactiveClientStandardServerInteropTest {
     public void oneToOne() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Single<String> rxRequest = Single.just("World");
-        Single<String> rxResponse = stub.sayHello(rxRequest.map(this::toRequest)).map(this::fromResponse);
+        Single<String> rxResponse = rxRequest
+                .map(this::toRequest)
+                .compose(stub::sayHello)
+                .map(this::fromResponse);
 
         TestObserver<String> test = rxResponse.test();
         test.awaitTerminalEvent(1, TimeUnit.SECONDS);
@@ -130,7 +133,10 @@ public class ReactiveClientStandardServerInteropTest {
     public void oneToMany() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Single<String> rxRequest = Single.just("World");
-        Flowable<String> rxResponse = stub.sayHelloRespStream(rxRequest.map(this::toRequest)).map(this::fromResponse);
+        Flowable<String> rxResponse = rxRequest
+                .map(this::toRequest)
+                .as(stub::sayHelloRespStream)
+                .map(this::fromResponse);
 
         TestSubscriber<String> test = rxResponse.test();
         test.awaitTerminalEvent(1, TimeUnit.SECONDS);
@@ -143,7 +149,10 @@ public class ReactiveClientStandardServerInteropTest {
     public void manyToOne() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Flowable<String> rxRequest = Flowable.just("A", "B", "C");
-        Single<String> rxResponse = stub.sayHelloReqStream(rxRequest.map(this::toRequest)).map(this::fromResponse);
+        Single<String> rxResponse = rxRequest
+                .map(this::toRequest)
+                .as(stub::sayHelloReqStream)
+                .map(this::fromResponse);
 
         TestObserver<String> test = rxResponse.test();
         test.awaitTerminalEvent(1, TimeUnit.SECONDS);
@@ -156,7 +165,10 @@ public class ReactiveClientStandardServerInteropTest {
     public void manyToMany() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
         Flowable<String> rxRequest = Flowable.just("A", "B", "C", "D");
-        Flowable<String> rxResponse = stub.sayHelloBothStream(rxRequest.map(this::toRequest)).map(this::fromResponse);
+        Flowable<String> rxResponse = rxRequest
+                .map(this::toRequest)
+                .compose(stub::sayHelloBothStream)
+                .map(this::fromResponse);
 
         TestSubscriber<String> test = rxResponse.test();
         test.awaitTerminalEvent(1, TimeUnit.SECONDS);

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ServerErrorIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/ServerErrorIntegrationTest.java
@@ -63,7 +63,7 @@ public class ServerErrorIntegrationTest {
     @Test
     public void oneToOne() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
-        Single<HelloResponse> resp = stub.sayHello(Single.just(HelloRequest.getDefaultInstance()));
+        Single<HelloResponse> resp = Single.just(HelloRequest.getDefaultInstance()).compose(stub::sayHello);
         TestObserver<HelloResponse> test = resp.test();
 
         test.awaitTerminalEvent(3, TimeUnit.SECONDS);
@@ -74,7 +74,7 @@ public class ServerErrorIntegrationTest {
     @Test
     public void oneToMany() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
-        Flowable<HelloResponse> resp = stub.sayHelloRespStream(Single.just(HelloRequest.getDefaultInstance()));
+        Flowable<HelloResponse> resp = Single.just(HelloRequest.getDefaultInstance()).as(stub::sayHelloRespStream);
         TestSubscriber<HelloResponse> test = resp
                 .doOnNext(System.out::println)
                 .doOnError(throwable -> System.out.println(throwable.getMessage()))
@@ -90,7 +90,7 @@ public class ServerErrorIntegrationTest {
     @Test
     public void manyToOne() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
-        Single<HelloResponse> resp = stub.sayHelloReqStream(Flowable.just(HelloRequest.getDefaultInstance()));
+        Single<HelloResponse> resp = Flowable.just(HelloRequest.getDefaultInstance()).as(stub::sayHelloReqStream);
         TestObserver<HelloResponse> test = resp.test();
 
         test.awaitTerminalEvent(3, TimeUnit.SECONDS);
@@ -101,7 +101,7 @@ public class ServerErrorIntegrationTest {
     @Test
     public void manyToMany() {
         RxGreeterGrpc.RxGreeterStub stub = RxGreeterGrpc.newRxStub(channel);
-        Flowable<HelloResponse> resp = stub.sayHelloBothStream(Flowable.just(HelloRequest.getDefaultInstance()));
+        Flowable<HelloResponse> resp = Flowable.just(HelloRequest.getDefaultInstance()).compose(stub::sayHelloBothStream);
         TestSubscriber<HelloResponse> test = resp.test();
 
         test.awaitTerminalEvent(3, TimeUnit.SECONDS);


### PR DESCRIPTION
* Upgrade to RxJava 2.1.10 and reactive-streams-tck 1.0.2
* Convert tests and examples to `compose()` and `as()` form