### PR TITLE
Generate additional convenience stubs for unary client requests

### DIFF
--- a/common/reactive-grpc-gencommon/src/main/java/com/salesforce/reactivegrpc/gen/ReactiveGrpcGenerator.java
+++ b/common/reactive-grpc-gencommon/src/main/java/com/salesforce/reactivegrpc/gen/ReactiveGrpcGenerator.java
@@ -195,6 +195,10 @@ public abstract class ReactiveGrpcGenerator extends Generator {
         public boolean deprecated;
         public String javaDoc;
         public List<MethodContext> methods = new ArrayList<>();
+
+        public List<MethodContext> unaryRequestMethods() {
+            return methods.stream().filter(m -> !m.isManyInput).collect(Collectors.toList());
+        }
     }
 
     /**

--- a/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
+++ b/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
@@ -55,6 +55,18 @@ public final class {{className}} {
         }
 
         {{/methods}}
+        {{#unaryRequestMethods}}
+            {{#javaDoc}}
+        {{{javaDoc}}}
+           {{/javaDoc}}
+           {{#deprecated}}
+        @java.lang.Deprecated
+           {{/deprecated}}
+        public {{#isManyOutput}}reactor.core.publisher.Flux{{/isManyOutput}}{{^isManyOutput}}reactor.core.publisher.Mono{{/isManyOutput}}<{{outputType}}> {{methodName}}({{inputType}} reactorRequest) {
+           return com.salesforce.reactorgrpc.stub.ClientCalls.{{reactiveCallsMethodName}}(reactor.core.publisher.Mono.just(reactorRequest), delegateStub::{{methodName}});
+        }
+
+        {{/unaryRequestMethods}}
     }
 
     {{#javaDoc}}

--- a/rx-java/rxgrpc/src/main/resources/RxStub.mustache
+++ b/rx-java/rxgrpc/src/main/resources/RxStub.mustache
@@ -55,6 +55,18 @@ public final class {{className}} {
         }
 
         {{/methods}}
+        {{#unaryRequestMethods}}
+           {{#javaDoc}}
+        {{{javaDoc}}}
+           {{/javaDoc}}
+           {{#deprecated}}
+        @java.lang.Deprecated
+           {{/deprecated}}
+        public {{#isManyOutput}}io.reactivex.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.Single{{/isManyOutput}}<{{outputType}}> {{methodName}}({{inputType}} rxRequest) {
+           return com.salesforce.rxgrpc.stub.ClientCalls.{{reactiveCallsMethodName}}(io.reactivex.Single.just(rxRequest), delegateStub::{{methodNameCamelCase}});
+        }
+
+        {{/unaryRequestMethods}}
     }
 
     {{#javaDoc}}


### PR DESCRIPTION
Addresses #78 

When generating client stubs for operations with a unary request parameter, generate two methods. One with a reactive parameter and one with a simple type parameter.