### PR TITLE
Feature/grpc context on schedule hook

### DIFF
--- a/rx-java/README.md
+++ b/rx-java/README.md
@@ -109,7 +109,7 @@ switches threads. To solve this problem, you can add a hook that makes the Conte
 switch when RX switches threads:
 
 ```java
-RxJavaPlugins.setScheduleHandler(original -> Context.current().wrap(original))
+RxJavaPlugins.setScheduleHandler(new GrpcContextOnScheduleHook())
 ```    
     
 To make sure you only run this piece of code once, you can for example add a utiltily class 
@@ -122,7 +122,7 @@ public class RxContextPropagator {
 
 	public static void ensureInstalled() {
 		if (INSTALLED.compareAndSet(false, true)) {
-			RxJavaPlugins.setScheduleHandler(original -> Context.current().wrap(original));
+			RxJavaPlugins.setScheduleHandler(new GrpcContextOnScheduleHook());
 		}
 	}
 }

--- a/rx-java/rxgrpc-stub/pom.xml
+++ b/rx-java/rxgrpc-stub/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/GrpcContextOnScheduleHook.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/GrpcContextOnScheduleHook.java
@@ -1,0 +1,18 @@
+package com.salesforce.rxgrpc.stub;
+
+import io.grpc.Context;
+import io.reactivex.functions.Function;
+
+/**
+ * {@code GrpcContextOnScheduleHook} is a RxJava scheduler handler hook implementation for transferring the gRPC
+ * {@code Context} between RxJava Schedulers.
+ * <p>
+ * To install the hook, call {@code RxJavaPlugins.setScheduleHandler(new GrpcContextOnScheduleHook());} somewhere in
+ * your application startup.
+ */
+public class GrpcContextOnScheduleHook implements Function<Runnable, Runnable> {
+    @Override
+    public Runnable apply(Runnable runnable) {
+        return Context.current().wrap(runnable);
+    }
+}

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/GrpcContextOnScheduleHook.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/GrpcContextOnScheduleHook.java
@@ -1,3 +1,10 @@
+/*
+ *  Copyright (c) 2017, salesforce.com, inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package com.salesforce.rxgrpc.stub;
 
 import io.grpc.Context;

--- a/rx-java/rxgrpc-stub/src/test/java/com/salesforce/rxgrpc/stub/GrpcContextOnScheduleHookTest.java
+++ b/rx-java/rxgrpc-stub/src/test/java/com/salesforce/rxgrpc/stub/GrpcContextOnScheduleHookTest.java
@@ -1,0 +1,68 @@
+package com.salesforce.rxgrpc.stub;
+
+import io.grpc.Context;
+import io.reactivex.Observable;
+import io.reactivex.functions.Action;
+import io.reactivex.functions.Consumer;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.Schedulers;
+import org.awaitility.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+
+public class GrpcContextOnScheduleHookTest {
+    @Before
+    public void before() {
+        RxJavaPlugins.setScheduleHandler(new GrpcContextOnScheduleHook());
+    }
+
+    @After
+    public void after() {
+        RxJavaPlugins.setScheduleHandler(null);
+    }
+
+    @Test
+    public void GrpcContextPropagatesAcrossSchedulers() {
+        final Context.Key<String> contextKey = Context.key("key");
+
+        final AtomicBoolean done = new AtomicBoolean();
+
+        Context.current().withValue(contextKey, "foo").wrap(new Runnable() {
+            @Override
+            public void run() {
+                Observable.just(1, 2, 3)
+                        .observeOn(Schedulers.computation())
+                        .subscribeOn(Schedulers.io())
+                        .subscribe(
+                                new Consumer<Integer>() {
+                                    @Override
+                                    public void accept(Integer i) throws Exception {
+                                        System.out.println(i);
+                                        assertThat(contextKey.get()).isEqualTo("foo");
+                                    }
+                                },
+                                new Consumer<Throwable>() {
+                                    @Override
+                                    public void accept(Throwable throwable) throws Exception {
+
+                                    }
+                                },
+                                new Action() {
+                                    @Override
+                                    public void run() throws Exception {
+                                        done.set(true);
+                                    }
+                                });
+            }
+        }).run();
+
+        await().atMost(Duration.FIVE_HUNDRED_MILLISECONDS).untilTrue(done);
+    }
+}

--- a/rx-java/rxgrpc-stub/src/test/java/com/salesforce/rxgrpc/stub/GrpcContextOnScheduleHookTest.java
+++ b/rx-java/rxgrpc-stub/src/test/java/com/salesforce/rxgrpc/stub/GrpcContextOnScheduleHookTest.java
@@ -1,3 +1,10 @@
+/*
+ *  Copyright (c) 2017, salesforce.com, inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package com.salesforce.rxgrpc.stub;
 
 import io.grpc.Context;


### PR DESCRIPTION
Implement `GrpcContextOnScheduleHook` for easy gRPC `Context` propagation under RxJava.