### PR TITLE
Added maven-bundle-plugin to create the correct osgi headers

### DIFF
--- a/common/reactive-grpc-common/pom.xml
+++ b/common/reactive-grpc-common/pom.xml
@@ -18,7 +18,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>reactive-grpc-common</artifactId>
-    <packaging>bundle</packaging>
 
     <properties>
         <java.version>1.6</java.version>
@@ -88,11 +87,16 @@
             </plugin>
 
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.5.0</version>
-                <extensions>true</extensions>
-
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -102,20 +106,6 @@
                         </goals>
                     </execution>
                 </executions>
-
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            io.grpc,
-                            io.grpc.stub,
-                            org.reactivestreams,
-                            com.google.common.base
-                        </Import-Package>
-                        <Export-Package>
-							com.salesforce.reactivegrpc.common
-                        </Export-Package>
-                    </instructions>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/common/reactive-grpc-common/pom.xml
+++ b/common/reactive-grpc-common/pom.xml
@@ -18,6 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>reactive-grpc-common</artifactId>
+    <packaging>bundle</packaging>
 
     <properties>
         <java.version>1.6</java.version>
@@ -83,6 +84,37 @@
                         <artifactId>java16</artifactId>
                         <version>1.0</version>
                     </signature>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.0</version>
+                <extensions>true</extensions>
+
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            io.grpc,
+                            io.grpc.stub,
+                            org.reactivestreams,
+                            com.google.common.base
+                        </Import-Package>
+                        <Export-Package>
+							com.salesforce.reactivegrpc.common
+                        </Export-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>

--- a/reactor/reactor-grpc-stub/pom.xml
+++ b/reactor/reactor-grpc-stub/pom.xml
@@ -18,6 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>reactor-grpc-stub</artifactId>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -67,6 +68,42 @@
                 <configuration>
                     <configLocation>../../checkstyle.xml</configLocation>
                     <suppressionsLocation>../../checkstyle_ignore.xml</suppressionsLocation>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.0</version>
+                <extensions>true</extensions>
+
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            com.google.common.base,
+                            com.google.common.util.concurrent,
+                            com.salesforce.reactivegrpc.common,
+                            io.grpc,
+                            io.grpc.stub,
+                            org.reactivestreams,
+                            reactor.core,
+                            reactor.core.publisher,
+                            reactor.util.context
+                        </Import-Package>
+                        <Export-Package>
+                            com.salesforce.reactorgrpc.stub
+                        </Export-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>

--- a/reactor/reactor-grpc-stub/pom.xml
+++ b/reactor/reactor-grpc-stub/pom.xml
@@ -18,7 +18,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>reactor-grpc-stub</artifactId>
-    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -70,13 +69,17 @@
                     <suppressionsLocation>../../checkstyle_ignore.xml</suppressionsLocation>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.5.0</version>
-                <extensions>true</extensions>
-
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -86,25 +89,6 @@
                         </goals>
                     </execution>
                 </executions>
-
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            com.google.common.base,
-                            com.google.common.util.concurrent,
-                            com.salesforce.reactivegrpc.common,
-                            io.grpc,
-                            io.grpc.stub,
-                            org.reactivestreams,
-                            reactor.core,
-                            reactor.core.publisher,
-                            reactor.util.context
-                        </Import-Package>
-                        <Export-Package>
-                            com.salesforce.reactorgrpc.stub
-                        </Export-Package>
-                    </instructions>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/rx-java/rxgrpc-stub/pom.xml
+++ b/rx-java/rxgrpc-stub/pom.xml
@@ -18,7 +18,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>rxgrpc-stub</artifactId>
-    <packaging>bundle</packaging>
 
     <properties>
         <java.version>1.6</java.version>
@@ -99,13 +98,17 @@
                     </signature>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.5.0</version>
-                <extensions>true</extensions>
-
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -115,25 +118,6 @@
                         </goals>
                     </execution>
                 </executions>
-
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            com.google.common.base,
-                            com.google.common.util.concurrent,
-                            com.salesforce.reactivegrpc.common,
-                            io.grpc,
-                            io.grpc.stub,
-                            io.reactivex,
-                            java.util.concurrent,
-                            java.util.concurrent.atomic,
-                            org.reactivestreams,
-                        </Import-Package>
-                        <Export-Package>
-                            com.salesforce.rxgrpc.stub
-                        </Export-Package>
-                    </instructions>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/rx-java/rxgrpc-stub/pom.xml
+++ b/rx-java/rxgrpc-stub/pom.xml
@@ -18,6 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>rxgrpc-stub</artifactId>
+    <packaging>bundle</packaging>
 
     <properties>
         <java.version>1.6</java.version>
@@ -96,6 +97,42 @@
                         <artifactId>java16</artifactId>
                         <version>1.0</version>
                     </signature>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.0</version>
+                <extensions>true</extensions>
+
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            com.google.common.base,
+                            com.google.common.util.concurrent,
+                            com.salesforce.reactivegrpc.common,
+                            io.grpc,
+                            io.grpc.stub,
+                            io.reactivex,
+                            java.util.concurrent,
+                            java.util.concurrent.atomic,
+                            org.reactivestreams,
+                        </Import-Package>
+                        <Export-Package>
+                            com.salesforce.rxgrpc.stub
+                        </Export-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Fixes #132

The maven-bundle-plugin in used to add the osgi headers so that the bundles can be used in an osgi environment.