### PR TITLE
Fix broken comments

### DIFF
--- a/common/reactive-grpc-gencommon/src/main/java/com/salesforce/reactivegrpc/gen/ReactiveGrpcGenerator.java
+++ b/common/reactive-grpc-gencommon/src/main/java/com/salesforce/reactivegrpc/gen/ReactiveGrpcGenerator.java
@@ -171,6 +171,7 @@ public abstract class ReactiveGrpcGenerator extends Generator {
             StringBuilder builder = new StringBuilder("/**\n")
                     .append(prefix).append(" * <pre>\n");
             Arrays.stream(HtmlEscapers.htmlEscaper().escape(comments).split("\n"))
+                    .map(line -> line.replace("*/", "&#42;&#47;").replace("*", "&#42;"))
                     .forEach(line -> builder.append(prefix).append(" * ").append(line).append("\n"));
             builder
                     .append(prefix).append(" * </pre>\n")


### PR DESCRIPTION
Compile proto with comments like [this](https://github.com/googleapis/googleapis/blob/51145ff7812d2bb44c1219d0b76dac92a8bd94b2/google/example/library/v1/library.proto#L39) leads to generate broken java class

Example:
```
// - Each Shelf has a collection of [Book][google.example.library.v1.Book]
//   resources, named `shelves/*/books/*`
service LibraryService {
...
```

Result:
```
 /**
     * <pre>
     *  - Each Shelf has a collection of [Book][google.example.library.v1.Book]
     *    resources, named `shelves/*/books/*`
     * </pre>
     */
```

Fixed:
```
 /**
     * <pre>
     *  - Each Shelf has a collection of [Book][google.example.library.v1.Book]
     *    resources, named `shelves/&#42;&#47;books/&#42;`
     * </pre>
     */
```