### PR TITLE
Create Bazel rules for generating reactive bindings

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+demos/bazel

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dependency-reduced-pom.xml
 .checkstyle
 .classpath
 .project
+bazel-*
+.ijwb/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,9 @@
+workspace(name = "com_salesforce_servicelibs_reactive_grpc")
+
+load("//bazel:repositories.bzl", "repositories")
+
+repositories()
+
+load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
+
+grpc_java_repositories()

--- a/bazel/java_reactive_grpc_library.bzl
+++ b/bazel/java_reactive_grpc_library.bzl
@@ -1,0 +1,145 @@
+load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_runtime_toolchain", "find_java_toolchain")
+
+# Taken from bazelbuild/rules_go license: Apache 2
+# https://github.com/bazelbuild/rules_go/blob/528f6faf83f85c23da367d61f784893d1b3bd72b/proto/compiler.bzl#L94
+# replaced `prefix = paths.join(..` with `prefix = "/".join(..`
+def _proto_path(src, proto):
+    """proto_path returns the string used to import the proto. This is the proto
+    source path within its repository, adjusted by import_prefix and
+    strip_import_prefix.
+
+    Args:
+        src: the proto source File.
+        proto: the ProtoInfo provider.
+
+    Returns:
+        An import path string.
+    """
+    if not hasattr(proto, "proto_source_root"):
+        # Legacy path. Remove when Bazel minimum version >= 0.21.0.
+        path = src.path
+        root = src.root.path
+        ws = src.owner.workspace_root
+        if path.startswith(root):
+            path = path[len(root):]
+        if path.startswith("/"):
+            path = path[1:]
+        if path.startswith(ws):
+            path = path[len(ws):]
+        if path.startswith("/"):
+            path = path[1:]
+        return path
+
+    if proto.proto_source_root == ".":
+        # true if proto sources were generated
+        prefix = src.root.path + "/"
+    elif proto.proto_source_root.startswith(src.root.path):
+        # sometimes true when import paths are adjusted with import_prefix
+        prefix = proto.proto_source_root + "/"
+    else:
+        # usually true when paths are not adjusted
+        prefix = "/".join([src.root.path, proto.proto_source_root]) + "/"
+    if not src.path.startswith(prefix):
+        # sometimes true when importing multiple adjusted protos
+        return src.path
+    return src.path[len(prefix):]
+
+def _reactive_grpc_library_impl(ctx):
+    proto = ctx.attr.proto[ProtoInfo]
+    descriptor_set_in = proto.transitive_descriptor_sets
+
+    gensrcjar = ctx.actions.declare_file("%s-proto-gensrc.jar" % ctx.label.name)
+
+    args = ctx.actions.args()
+    args.add(ctx.executable.reactive_plugin.path, format = "--plugin=protoc-gen-reactive-grpc-plugin=%s")
+    args.add("--reactive-grpc-plugin_out=:{0}".format(gensrcjar.path))
+    args.add_joined("--descriptor_set_in", descriptor_set_in, join_with = ":")
+    for src in proto.check_deps_sources.to_list():
+        args.add(_proto_path(src, proto))
+
+    ctx.actions.run(
+        inputs = descriptor_set_in,
+        tools = [ctx.executable.reactive_plugin],
+        outputs = [gensrcjar],
+        executable = ctx.executable._protoc,
+        arguments = [args],
+    )
+
+    deps = [java_common.make_non_strict(dep[JavaInfo]) for dep in ctx.attr.deps]
+    deps += [dep[JavaInfo] for dep in ctx.attr.reactive_deps]
+
+    java_info = java_common.compile(
+        ctx,
+        deps = deps,
+        host_javabase = find_java_runtime_toolchain(ctx, ctx.attr._host_javabase),
+        java_toolchain = find_java_toolchain(ctx, ctx.attr._java_toolchain),
+        output = ctx.outputs.jar,
+        output_source_jar = ctx.outputs.srcjar,
+        source_jars = [gensrcjar],
+    )
+
+    return [java_info]
+
+_reactive_grpc_library = rule(
+    attrs = {
+        "proto": attr.label(
+            mandatory = True,
+            providers = [ProtoInfo],
+        ),
+        "deps": attr.label_list(
+            mandatory = True,
+            allow_empty = False,
+            providers = [JavaInfo],
+        ),
+        "_protoc": attr.label(
+            default = Label("@com_google_protobuf//:protoc"),
+            executable = True,
+            cfg = "host",
+        ),
+        "reactive_deps": attr.label_list(
+            mandatory = True,
+            allow_empty = False,
+            providers = [JavaInfo],
+        ),
+        "reactive_plugin": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "host",
+        ),
+        "_java_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+        ),
+        "_host_javabase": attr.label(
+            cfg = "host",
+            default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
+        ),
+    },
+    fragments = ["java"],
+    outputs = {
+        "jar": "lib%{name}.jar",
+        "srcjar": "lib%{name}-src.jar",
+    },
+    provides = [JavaInfo],
+    implementation = _reactive_grpc_library_impl,
+)
+
+def reactor_grpc_library(**kwargs):
+    _reactive_grpc_library(
+        reactive_plugin = "@com_salesforce_servicelibs_reactive_grpc//reactor/reactor-grpc:reactor_grpc_bin",
+        reactive_deps = [
+            "@com_salesforce_servicelibs_reactive_grpc//reactor/reactor-grpc-stub",
+            "@io_projectreactor_reactor_core",
+        ],
+        **kwargs
+    )
+
+def rx_grpc_library(**kwargs):
+    _reactive_grpc_library(
+        reactive_plugin = "@com_salesforce_servicelibs_reactive_grpc//rx-java/rxgrpc:rxgrpc_bin",
+        reactive_deps = [
+            "@com_salesforce_servicelibs_reactive_grpc//rx-java/rxgrpc-stub",
+            "@com_salesforce_servicelibs_reactive_grpc//common/reactive-grpc-common",
+            "@io_reactivex_rxjava2_rxjava",
+        ],
+        **kwargs
+    )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,0 +1,69 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+
+def repositories(
+        omit_org_reactivestreams_reactive_streams = False,
+        omit_io_projectreactor_reactor_core = False,
+        omit_io_reactivex_rxjava2_rxjava = False,
+        omit_io_grpc_grpc_java = False,
+        omit_com_salesforce_servicelibs_jprotoc = False,
+        omit_com_github_spullara_mustache_java_compiler = False):
+    if not omit_org_reactivestreams_reactive_streams:
+        java_import_external(
+            name = "org_reactivestreams_reactive_streams",
+            jar_urls = ["http://central.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2.jar"],
+            jar_sha256 = "cc09ab0b140e0d0496c2165d4b32ce24f4d6446c0a26c5dc77b06bdf99ee8fae",
+            srcjar_urls = ["http://central.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2-sources.jar"],
+            srcjar_sha256 = "963a6480f46a64013d0f144ba41c6c6e63c4d34b655761717a436492886f3667",
+            licenses = ["notice"],  # Apache 2.0
+        )
+
+    if not omit_io_projectreactor_reactor_core:
+        java_import_external(
+            name = "io_projectreactor_reactor_core",
+            jar_urls = ["http://central.maven.org/maven2/io/projectreactor/reactor-core/3.2.6.RELEASE/reactor-core-3.2.6.RELEASE.jar"],
+            jar_sha256 = "8962081aa9e0fbe1685cc2746471b232f93f58e269cc89b54efebcb99c65af1a",
+            srcjar_urls = ["http://central.maven.org/maven2/io/projectreactor/reactor-core/3.2.6.RELEASE/reactor-core-3.2.6.RELEASE-sources.jar"],
+            srcjar_sha256 = "b871669ed12aee2af22f20a611bf871c7f848caede85bc19b0ef08ef5f79bc46",
+            licenses = ["notice"],  # Apache 2.0
+        )
+
+    if not omit_io_reactivex_rxjava2_rxjava:
+        java_import_external(
+            name = "io_reactivex_rxjava2_rxjava",
+            jar_urls = ["http://central.maven.org/maven2/io/reactivex/rxjava2/rxjava/2.2.7/rxjava-2.2.7.jar"],
+            jar_sha256 = "23798f1b5fecac2aaaa3e224fd0e73f41dc081802c7bd2a6e91030bad36b9013",
+            srcjar_urls = ["http://central.maven.org/maven2/io/reactivex/rxjava2/rxjava/2.2.7/rxjava-2.2.7-sources.jar"],
+            srcjar_sha256 = "b7ee7e2b2ce07eda19755e511757427701f4081a051cace1efd69cf0bfcc8ff2",
+            licenses = ["notice"],  # Apache 2.0
+        )
+
+    if not omit_io_grpc_grpc_java:
+        io_grpc_grpc_java_version = "v1.21.0"
+
+        http_archive(
+            name = "io_grpc_grpc_java",
+            sha256 = "2137a2b568e8266d6c269c995c7ba68db3d8d7d7936087c540fdbfadae577f81",
+            strip_prefix = "grpc-java-%s" % io_grpc_grpc_java_version[1:],
+            urls = ["https://github.com/grpc/grpc-java/archive/%s.zip" % io_grpc_grpc_java_version],
+        )
+
+    if not omit_com_salesforce_servicelibs_jprotoc:
+        java_import_external(
+            name = "com_salesforce_servicelibs_jprotoc",
+            jar_urls = ["http://central.maven.org/maven2/com/salesforce/servicelibs/jprotoc/0.9.1/jprotoc-0.9.1.jar"],
+            jar_sha256 = "55d78aafa930693856055e7d1d63414670beb59a9b253ece5cf546541b4bbd07",
+            srcjar_urls = ["http://central.maven.org/maven2/com/salesforce/servicelibs/jprotoc/0.9.1/jprotoc-0.9.1-sources.jar"],
+            srcjar_sha256 = "ba023a2097874fa7131c277eab69ca748928627bea122a48ef9cb54ca8dafd91",
+            licenses = ["notice"],  # BSD 3-Clause
+        )
+
+    if not omit_com_github_spullara_mustache_java_compiler:
+        java_import_external(
+            name = "com_github_spullara_mustache_java_compiler",
+            jar_urls = ["http://central.maven.org/maven2/com/github/spullara/mustache/java/compiler/0.9.6/compiler-0.9.6.jar"],
+            jar_sha256 = "c4d697fd3619cb616cc5e22e9530c8a4fd4a8e9a76953c0655ee627cb2d22318",
+            srcjar_urls = ["http://central.maven.org/maven2/com/github/spullara/mustache/java/compiler/0.9.6/compiler-0.9.6-sources.jar"],
+            srcjar_sha256 = "fb3cf89e4daa0aaa4e659aca12a8ddb0d7b605271285f3e108201e0a389b4c7a",
+            licenses = ["notice"],  # Apache 2.0
+        )

--- a/common/reactive-grpc-common/BUILD.bazel
+++ b/common/reactive-grpc-common/BUILD.bazel
@@ -1,0 +1,11 @@
+java_library(
+    name = "reactive-grpc-common",
+    srcs = glob(["src/main/**/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_guava_guava",
+        "@io_grpc_grpc_java//core",
+        "@io_grpc_grpc_java//stub",
+        "@org_reactivestreams_reactive_streams",
+    ],
+)

--- a/common/reactive-grpc-gencommon/BUILD.bazel
+++ b/common/reactive-grpc-gencommon/BUILD.bazel
@@ -1,0 +1,12 @@
+java_library(
+    name = "reactive-grpc-gencommon",
+    srcs = glob(["src/main/**/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_salesforce_servicelibs_jprotoc",
+        "@com_github_spullara_mustache_java_compiler",
+        "@io_grpc_grpc_java//protobuf",
+        "@com_google_guava_guava",
+        "@com_google_protobuf//:protobuf_java",
+    ],
+)

--- a/demos/bazel/.bazelrc
+++ b/demos/bazel/.bazelrc
@@ -1,0 +1,5 @@
+# Required because by default Bazel strips source code info from proto file descriptors
+# (see https://github.com/bazelbuild/bazel/issues/3971)
+# and com.salesforce.reactivegrpc.gen.ReactiveGrpcGenerator does not generate any
+# services without source code info present
+build --protocopt=--include_source_info

--- a/demos/bazel/.bazelrc
+++ b/demos/bazel/.bazelrc
@@ -1,5 +1,0 @@
-# Required because by default Bazel strips source code info from proto file descriptors
-# (see https://github.com/bazelbuild/bazel/issues/3971)
-# and com.salesforce.reactivegrpc.gen.ReactiveGrpcGenerator does not generate any
-# services without source code info present
-build --protocopt=--include_source_info

--- a/demos/bazel/README.md
+++ b/demos/bazel/README.md
@@ -1,0 +1,50 @@
+# Bazel Reactive gRPC
+
+This demo shows how to use the Reactive-gRPC Bazel rules.
+
+## Setup
+
+Add `build --protocopt=--include_source_info` to your `.bazelrc` file.
+This needs to be done because by default Bazel strips source code info from proto file descriptors. 
+This information is required by the Reactive-gRPC generator, **it does not generate services without it**.
+
+Include this project as an external dependency in your `WORKSPACE`.
+
+    load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+    http_archive(
+        name = "com_salesforce_servicelibs_reactive_grpc",
+        sha256 = <sha256>,
+        strip_prefix = "reactive-grpc-%s" % <version>,
+        url = "https://github.com/salesforce/reactive-grpc/archive/%s.zip" % <version>,
+    )
+
+    load("@com_salesforce_servicelibs_reactive_grpc//bazel:repositories.bzl", reactive_grpc_repositories="repositories")
+    reactive_grpc_repositories()
+    
+    load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
+    grpc_java_repositories()
+
+
+In your build files use the following to generate reactive bindings.
+
+
+    load("@com_salesforce_servicelibs_reactive_grpc//bazel:java_reactive_grpc_library.bzl", "reactor_grpc_library", "rx_grpc_library")
+    
+    reactor_grpc_library(
+        name = "helloworld_reactor_grpc",
+        proto = ":helloworld_proto",
+        visibility = ["//visibility:public"],
+        deps = [":helloworld_java_grpc"],
+    )
+    
+    rx_grpc_library(
+        name = "helloworld_rx_grpc",
+        proto = ":helloworld_proto",
+        visibility = ["//visibility:public"],
+        deps = [":helloworld_java_grpc"],
+    )
+
+These targets can be used like any other `java_library` targets.
+Via the `deps` attribute they depend on their respective `java_grpc_library` targets.
+For more information on creating these see https://github.com/grpc/grpc-java.

--- a/demos/bazel/README.md
+++ b/demos/bazel/README.md
@@ -4,10 +4,6 @@ This demo shows how to use the Reactive-gRPC Bazel rules.
 
 ## Setup
 
-Add `build --protocopt=--include_source_info` to your `.bazelrc` file.
-This needs to be done because by default Bazel strips source code info from proto file descriptors. 
-This information is required by the Reactive-gRPC generator, **it does not generate services without it**.
-
 Include this project as an external dependency in your `WORKSPACE`.
 
     load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/demos/bazel/README.md
+++ b/demos/bazel/README.md
@@ -4,6 +4,9 @@ This demo shows how to use the Reactive-gRPC Bazel rules.
 
 ## Setup
 
+(Optional) Add `build --protocopt=--include_source_info` to your `.bazelrc` file.
+When enabled the Reactive-gRPC generator will include comments from the proto files in the generated code.
+
 Include this project as an external dependency in your `WORKSPACE`.
 
     load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/demos/bazel/WORKSPACE
+++ b/demos/bazel/WORKSPACE
@@ -1,0 +1,14 @@
+workspace(name = "com_salesforce_servicelibs_reactive_grpc_demos_bazel")
+
+local_repository(
+    name = "com_salesforce_servicelibs_reactive_grpc",
+    path = "../.."
+)
+
+load("@com_salesforce_servicelibs_reactive_grpc//bazel:repositories.bzl", "repositories")
+
+repositories()
+
+load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
+
+grpc_java_repositories()

--- a/demos/bazel/src/main/java/com/salesforce/servicelibs/reactivegrpc/BUILD.bazel
+++ b/demos/bazel/src/main/java/com/salesforce/servicelibs/reactivegrpc/BUILD.bazel
@@ -1,0 +1,21 @@
+java_library(
+    name = "reactivegrpc",
+    srcs = glob(["*.java"]),
+    visibility = ["//src/test:__subpackages__"],
+    deps = [
+        "//src/main/proto:helloworld_java_grpc",
+        "//src/main/proto:helloworld_java_proto",
+        "//src/main/proto:helloworld_rx_grpc",
+        "//src/main/proto:nested_java_proto",
+        "//src/main/proto:nested_rx_grpc",
+        "@io_grpc_grpc_java//core",
+        "@io_grpc_grpc_java//core:inprocess",
+        "@io_reactivex_rxjava2_rxjava",
+    ],
+)
+
+java_binary(
+    name = "reactivegrpc_bin",
+    main_class = "com.salesforce.servicelibs.reactivegrpc.BazelProof",
+    runtime_deps = [":reactivegrpc"],
+)

--- a/demos/bazel/src/main/java/com/salesforce/servicelibs/reactivegrpc/BazelProof.java
+++ b/demos/bazel/src/main/java/com/salesforce/servicelibs/reactivegrpc/BazelProof.java
@@ -1,0 +1,57 @@
+package com.salesforce.servicelibs.reactivegrpc;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.reactivex.Single;
+
+public class BazelProof extends RxGreeterGrpc.GreeterImplBase {
+    public static void main(String[] args) throws Exception {
+        BazelProof proof = new BazelProof();
+        try {
+            proof.startServer();
+            System.out.println(proof.doClient("World"));
+        } finally {
+            proof.stopServer();
+        }
+    }
+
+    private Server server;
+
+    public void startServer() throws Exception {
+        server = InProcessServerBuilder
+            .forName("BazelProof")
+            .addService(this)
+            .build()
+            .start();
+    }
+
+    public void stopServer() {
+        if (server != null) {
+            server.shutdownNow();
+        }
+    }
+
+    public String doClient(String name) {
+        ManagedChannel channel = InProcessChannelBuilder
+            .forName("BazelProof")
+            .build();
+        try {
+            GreeterGrpc.GreeterBlockingStub stub = GreeterGrpc.newBlockingStub(channel);
+            HelloRequest request = HelloRequest.newBuilder().setName(name).build();
+            HelloResponse response = stub.sayHello(request);
+            return response.getMessage();
+        } finally {
+            channel.shutdownNow();
+        }
+    }
+
+    @Override
+    public Single<HelloResponse> sayHello(Single<HelloRequest> request) {
+        return request
+            .map(HelloRequest::getName)
+            .map(name -> "Hello " + name)
+            .map(message -> HelloResponse.newBuilder().setMessage(message).build());
+    }
+}

--- a/demos/bazel/src/main/proto/BUILD.bazel
+++ b/demos/bazel/src/main/proto/BUILD.bazel
@@ -1,0 +1,69 @@
+load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("@com_salesforce_servicelibs_reactive_grpc//bazel:java_reactive_grpc_library.bzl", "reactor_grpc_library", "rx_grpc_library")
+
+proto_library(
+    name = "helloworld_proto",
+    srcs = ["helloworld.proto"],
+    visibility = ["//visibility:public"],
+)
+
+java_proto_library(
+    name = "helloworld_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":helloworld_proto"],
+)
+
+java_grpc_library(
+    name = "helloworld_java_grpc",
+    srcs = ["helloworld_proto"],
+    visibility = ["//visibility:public"],
+    deps = ["helloworld_java_proto"],
+)
+
+reactor_grpc_library(
+    name = "helloworld_reactor_grpc",
+    proto = ":helloworld_proto",
+    visibility = ["//visibility:public"],
+    deps = [":helloworld_java_grpc"],
+)
+
+rx_grpc_library(
+    name = "helloworld_rx_grpc",
+    proto = ":helloworld_proto",
+    visibility = ["//visibility:public"],
+    deps = [":helloworld_java_grpc"],
+)
+
+proto_library(
+    name = "nested_proto",
+    srcs = ["nested.proto"],
+    visibility = ["//visibility:public"],
+    deps = [":helloworld_proto"],
+)
+
+java_proto_library(
+    name = "nested_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":nested_proto"],
+)
+
+java_grpc_library(
+    name = "nested_java_grpc",
+    srcs = [":nested_proto"],
+    visibility = ["//visibility:public"],
+    deps = [":nested_java_proto"],
+)
+
+reactor_grpc_library(
+    name = "nested_reactor_grpc",
+    proto = ":nested_proto",
+    visibility = ["//visibility:public"],
+    deps = [":nested_java_grpc"],
+)
+
+rx_grpc_library(
+    name = "nested_rx_grpc",
+    proto = ":nested_proto",
+    visibility = ["//visibility:public"],
+    deps = [":nested_java_grpc"],
+)

--- a/demos/bazel/src/main/proto/helloworld.proto
+++ b/demos/bazel/src/main/proto/helloworld.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package helloworld;
+
+option java_multiple_files = true;
+option java_package = "com.salesforce.servicelibs.reactivegrpc";
+option java_outer_classname = "HelloWorldProto";
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloResponse) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloResponse {
+    string message = 1;
+}

--- a/demos/bazel/src/main/proto/nested.proto
+++ b/demos/bazel/src/main/proto/nested.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-// Protos are imported using the path from package root to proto.
+// When using Bazel protos must be imported using the path from workspace root to proto.
 // In the future, specifying a (strip_)import_prefix in the proto_library rule will make this less verbose.
 // For now this blocks on https://github.com/grpc/grpc-java/pull/5621
 import "src/main/proto/helloworld.proto";

--- a/demos/bazel/src/main/proto/nested.proto
+++ b/demos/bazel/src/main/proto/nested.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+// Protos are imported using the path from package root to proto.
+// In the future, specifying a (strip_)import_prefix in the proto_library rule will make this less verbose.
+// For now this blocks on https://github.com/grpc/grpc-java/pull/5621
+import "src/main/proto/helloworld.proto";
+
+package pkg.test;
+
+service TestService {
+    rpc Test (InnerMessage.TestRequest) returns (InnerMessage.TestResponse);
+    rpc ImportTest (helloworld.HelloRequest) returns (helloworld.HelloResponse);
+}
+
+message InnerMessage {
+    message TestRequest {
+        string data = 1;
+    }
+
+    message TestResponse {
+        string data = 1;
+        string error = 2;
+    }
+}

--- a/demos/bazel/src/test/java/com/salesforce/servicelibs/reactivegrpc/BUILD.bazel
+++ b/demos/bazel/src/test/java/com/salesforce/servicelibs/reactivegrpc/BUILD.bazel
@@ -1,0 +1,7 @@
+java_test(
+    name = "reactivegrpc",
+    size = "small",
+    srcs = glob(["*.java"]),
+    test_class = "com.salesforce.servicelibs.reactivegrpc.BazelProofTest",
+    deps = ["//src/main/java/com/salesforce/servicelibs/reactivegrpc"],
+)

--- a/demos/bazel/src/test/java/com/salesforce/servicelibs/reactivegrpc/BazelProofTest.java
+++ b/demos/bazel/src/test/java/com/salesforce/servicelibs/reactivegrpc/BazelProofTest.java
@@ -1,0 +1,19 @@
+package com.salesforce.servicelibs.reactivegrpc;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BazelProofTest {
+    @Test
+    public void bazelProof() throws Exception {
+        BazelProof proof = new BazelProof();
+        try {
+            proof.startServer();
+            String result = proof.doClient("World");
+            assertEquals("Hello World", result);
+        } finally {
+            proof.stopServer();
+        }
+    }
+}

--- a/reactor/reactor-grpc-stub/BUILD.bazel
+++ b/reactor/reactor-grpc-stub/BUILD.bazel
@@ -1,0 +1,15 @@
+java_library(
+    name = "reactor-grpc-stub",
+    srcs = glob(["src/main/**/*.java"]),
+    # Disable error prone build failure (triggered by unused return)
+    javacopts = ["-XepDisableAllChecks"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//common/reactive-grpc-common",
+        "@com_google_guava_guava",
+        "@io_grpc_grpc_java//core",
+        "@io_grpc_grpc_java//stub",
+        "@io_projectreactor_reactor_core",
+        "@org_reactivestreams_reactive_streams",
+    ],
+)

--- a/reactor/reactor-grpc/BUILD.bazel
+++ b/reactor/reactor-grpc/BUILD.bazel
@@ -1,0 +1,16 @@
+java_library(
+    name = "reactor_grpc",
+    srcs = glob(["src/main/**/*.java"]),
+    resources = ["src/main/resources/ReactorStub.mustache"],
+    deps = [
+        "//common/reactive-grpc-gencommon",
+        "@com_salesforce_servicelibs_jprotoc",
+    ],
+)
+
+java_binary(
+    name = "reactor_grpc_bin",
+    main_class = "com.salesforce.reactorgrpc.ReactorGrpcGenerator",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":reactor_grpc"],
+)

--- a/rx-java/rxgrpc-stub/BUILD.bazel
+++ b/rx-java/rxgrpc-stub/BUILD.bazel
@@ -1,0 +1,16 @@
+java_library(
+    name = "rxgrpc-stub",
+    srcs = glob(["src/main/**/*.java"]),
+    # Disable error prone build failure (triggered by unused return)
+    javacopts = ["-XepDisableAllChecks"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//common/reactive-grpc-common",
+        "@com_google_guava_guava",
+        "@io_grpc_grpc_java//context",
+        "@io_grpc_grpc_java//core",
+        "@io_grpc_grpc_java//stub",
+        "@io_reactivex_rxjava2_rxjava",
+        "@org_reactivestreams_reactive_streams",
+    ],
+)

--- a/rx-java/rxgrpc/BUILD.bazel
+++ b/rx-java/rxgrpc/BUILD.bazel
@@ -1,0 +1,16 @@
+java_library(
+    name = "rxgrpc",
+    srcs = glob(["src/main/**/*.java"]),
+    resources = ["src/main/resources/RxStub.mustache"],
+    deps = [
+        "//common/reactive-grpc-gencommon",
+        "@com_salesforce_servicelibs_jprotoc",
+    ],
+)
+
+java_binary(
+    name = "rxgrpc_bin",
+    main_class = "com.salesforce.rxgrpc.RxGrpcGenerator",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":rxgrpc"],
+)


### PR DESCRIPTION
Hi, finally some code! 

Resolves #164

This adds the following rules for generating reactive bindings using Bazel.
* `rx_grpc_library`
* `reactor_grpc_library`

Notes: 
1. I've tried to depend on the same dependency versions as used by Maven but was not able to for grpc-java because the .bzl script in that repository is out of date for v1.19.0.
1. Having to add the .bazelrc file is not a great solution because we force our users to do the same. The alternative is to rewrite the generator to only use source code info if present but this seemed out of scope for this change.
1. If possible, I would like to add this to the build server but I have 0 experience with CircleCI. If this is something you want I would really appreciate some help.