### PR TITLE
Allow to override prefetch on client and server side

### DIFF
--- a/common/reactive-grpc-common/src/main/java/com/salesforce/reactivegrpc/common/AbstractClientStreamObserverAndPublisher.java
+++ b/common/reactive-grpc-common/src/main/java/com/salesforce/reactivegrpc/common/AbstractClientStreamObserverAndPublisher.java
@@ -36,6 +36,15 @@ public abstract class AbstractClientStreamObserverAndPublisher<T>
         super(queue, onSubscribe, onTerminate);
     }
 
+    public AbstractClientStreamObserverAndPublisher(
+            Queue<T> queue,
+            Consumer<CallStreamObserver<?>> onSubscribe,
+            Runnable onTerminate,
+            int prefetch,
+            int lowTide) {
+        super(queue, prefetch, lowTide, onSubscribe, onTerminate);
+    }
+
     @Override
     public void beforeStart(ClientCallStreamObserver<T> requestStream) {
         super.onSubscribe(requestStream);

--- a/common/reactive-grpc-common/src/main/java/com/salesforce/reactivegrpc/common/AbstractServerStreamObserverAndPublisher.java
+++ b/common/reactive-grpc-common/src/main/java/com/salesforce/reactivegrpc/common/AbstractServerStreamObserverAndPublisher.java
@@ -26,10 +26,20 @@ public abstract class AbstractServerStreamObserverAndPublisher<T>
     private volatile boolean abandonDelayedCancel;
 
     public AbstractServerStreamObserverAndPublisher(
+        ServerCallStreamObserver<?> serverCallStreamObserver,
+        Queue<T> queue,
+        Consumer<CallStreamObserver<?>> onSubscribe) {
+        super(queue, onSubscribe);
+        super.onSubscribe(serverCallStreamObserver);
+    }
+
+    public AbstractServerStreamObserverAndPublisher(
             ServerCallStreamObserver<?> serverCallStreamObserver,
             Queue<T> queue,
-            Consumer<CallStreamObserver<?>> onSubscribe) {
-        super(queue, onSubscribe);
+            Consumer<CallStreamObserver<?>> onSubscribe,
+            int prefetch,
+            int lowTide) {
+        super(queue, prefetch, lowTide, onSubscribe);
         super.onSubscribe(serverCallStreamObserver);
     }
 

--- a/common/reactive-grpc-common/src/main/java/com/salesforce/reactivegrpc/common/AbstractStreamObserverAndPublisher.java
+++ b/common/reactive-grpc-common/src/main/java/com/salesforce/reactivegrpc/common/AbstractStreamObserverAndPublisher.java
@@ -64,8 +64,8 @@ public abstract class AbstractStreamObserverAndPublisher<T> extends AbstractUnim
     };
 
 
-    protected static final int DEFAULT_CHUNK_SIZE = 512;
-    protected static final int TWO_THIRDS_OF_DEFAULT_CHUNK_SIZE = DEFAULT_CHUNK_SIZE * 2 / 3;
+    public static final int DEFAULT_CHUNK_SIZE = 512;
+    public static final int TWO_THIRDS_OF_DEFAULT_CHUNK_SIZE = DEFAULT_CHUNK_SIZE * 2 / 3;
 
     private static final int UNSUBSCRIBED_STATE    = 0;
     private static final int SUBSCRIBED_ONCE_STATE = 1;

--- a/reactor/README.md
+++ b/reactor/README.md
@@ -128,6 +128,31 @@ Two context propagation techniques are:
 2. Make use of Reactor's [`subscriberContext()`](https://github.com/reactor/reactor-core/blob/master/docs/asciidoc/advancedFeatures.adoc#adding-a-context-to-a-reactive-sequence)
    API to capture the gRPC context in the call chain.
 
+## Configuration of flow control
+Reactor GRPC by default prefetch 512 items on client and server side. When the messages are bigger it
+can consume a lot of memory. One can override these default settings using ReactorCallOptions:
+
+Prefetch on client side (client consumes too slow):
+
+```java
+    ReactorMyAPIStub api = ReactorMyAPIGrpc.newReactorStub(channel)
+        .withOption(ReactorCallOptions.CALL_OPTIONS_PREFETCH, 16)
+        .withOption(ReactorCallOptions.CALL_OPTIONS_LOW_TIDE, 4);
+```
+
+Prefetch on server side (server consumes too slow):
+
+```java
+    // Override getCallOptions method in your *ImplBase service class.
+    // One can use methodId to do method specific override
+    @Override
+    protected CallOptions getCallOptions(int methodId) {
+        return CallOptions.DEFAULT
+            .withOption(ReactorCallOptions.CALL_OPTIONS_PREFETCH, 16)
+            .withOption(ReactorCallOptions.CALL_OPTIONS_LOW_TIDE, 4);
+    }
+```
+
 Modules
 =======
 

--- a/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ReactorCallOptions.java
+++ b/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ReactorCallOptions.java
@@ -11,7 +11,7 @@ import com.salesforce.reactivegrpc.common.AbstractStreamObserverAndPublisher;
 import io.grpc.CallOptions;
 
 /**
- * RX Call options.
+ * Reactor Call options.
  */
 public final class ReactorCallOptions {
 

--- a/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ReactorCallOptions.java
+++ b/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ReactorCallOptions.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2019, Salesforce.com, Inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.reactorgrpc.stub;
+
+import com.salesforce.reactivegrpc.common.AbstractStreamObserverAndPublisher;
+import io.grpc.CallOptions;
+
+/**
+ * RX Call options.
+ */
+public final class ReactorCallOptions {
+
+    private ReactorCallOptions() {
+    }
+
+    /**
+     * Sets Prefetch size of queue.
+     */
+    public static final io.grpc.CallOptions.Key<Integer> CALL_OPTIONS_PREFETCH =
+        io.grpc.CallOptions.Key.createWithDefault("reactivegrpc.internal.PREFETCH",
+            Integer.valueOf(AbstractStreamObserverAndPublisher.DEFAULT_CHUNK_SIZE));
+
+    /**
+     * Sets Low Tide of prefetch queue.
+     */
+    public static final io.grpc.CallOptions.Key<Integer> CALL_OPTIONS_LOW_TIDE =
+        io.grpc.CallOptions.Key.createWithDefault("reactivegrpc.internal.LOW_TIDE",
+            Integer.valueOf(AbstractStreamObserverAndPublisher.TWO_THIRDS_OF_DEFAULT_CHUNK_SIZE));
+
+
+    /**
+     * Utility function to get prefetch option.
+     */
+    public static int getPrefetch(final CallOptions options) {
+        return options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
+    }
+
+    /**
+     * Utility function to get low tide option together with validation.
+     */
+    public static int getLowTide(final CallOptions options) {
+        int prefetch = getPrefetch(options);
+        int lowTide = options == null ? CALL_OPTIONS_LOW_TIDE.getDefault() : options.getOption(CALL_OPTIONS_LOW_TIDE);
+        if (lowTide >= prefetch) {
+            throw new IllegalArgumentException(CALL_OPTIONS_LOW_TIDE + " must be less than " + CALL_OPTIONS_PREFETCH);
+        }
+        return lowTide;
+    }
+
+}

--- a/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ReactorClientStreamObserverAndPublisher.java
+++ b/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ReactorClientStreamObserverAndPublisher.java
@@ -30,6 +30,14 @@ class ReactorClientStreamObserverAndPublisher<T>
         super(Queues.<T>get(DEFAULT_CHUNK_SIZE).get(), onSubscribe, onTerminate);
     }
 
+    ReactorClientStreamObserverAndPublisher(
+            Consumer<CallStreamObserver<?>> onSubscribe,
+            Runnable onTerminate,
+            int prefetch,
+            int lowTide) {
+        super(Queues.<T>get(DEFAULT_CHUNK_SIZE).get(), onSubscribe, onTerminate, prefetch, lowTide);
+    }
+
     @Override
     public int requestFusion(int requestedMode) {
         if ((requestedMode & Fuseable.ASYNC) != 0) {

--- a/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ReactorServerStreamObserverAndPublisher.java
+++ b/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ReactorServerStreamObserverAndPublisher.java
@@ -24,8 +24,10 @@ class ReactorServerStreamObserverAndPublisher<T>
 
     ReactorServerStreamObserverAndPublisher(
             ServerCallStreamObserver<?> serverCallStreamObserver,
-            Consumer<CallStreamObserver<?>> onSubscribe) {
-        super(serverCallStreamObserver, Queues.<T>get(DEFAULT_CHUNK_SIZE).get(), onSubscribe);
+            Consumer<CallStreamObserver<?>> onSubscribe,
+            int prefetch,
+            int lowTide) {
+        super(serverCallStreamObserver, Queues.<T>get(DEFAULT_CHUNK_SIZE).get(), onSubscribe, prefetch, lowTide);
     }
 
     @Override

--- a/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ServerCalls.java
+++ b/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ServerCalls.java
@@ -7,14 +7,14 @@
 
 package com.salesforce.reactorgrpc.stub;
 
-import java.util.function.Function;
-
 import com.google.common.base.Preconditions;
+import io.grpc.CallOptions;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.util.function.Function;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -77,9 +77,14 @@ public final class ServerCalls {
      */
     public static <TRequest, TResponse> StreamObserver<TRequest> manyToOne(
             StreamObserver<TResponse> responseObserver,
-            Function<Flux<TRequest>, Mono<TResponse>> delegate) {
+            Function<Flux<TRequest>, Mono<TResponse>> delegate,
+            CallOptions options) {
+
+        final int prefetch = ReactorCallOptions.getPrefetch(options);
+        final int lowTide = ReactorCallOptions.getLowTide(options);
+
         ReactorServerStreamObserverAndPublisher<TRequest> streamObserverPublisher =
-                new ReactorServerStreamObserverAndPublisher<>((ServerCallStreamObserver<TResponse>) responseObserver, null);
+                new ReactorServerStreamObserverAndPublisher<>((ServerCallStreamObserver<TResponse>) responseObserver, null, prefetch, lowTide);
 
         try {
             Mono<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(Flux.from(streamObserverPublisher)));
@@ -112,9 +117,14 @@ public final class ServerCalls {
      */
     public static <TRequest, TResponse> StreamObserver<TRequest> manyToMany(
             StreamObserver<TResponse> responseObserver,
-            Function<Flux<TRequest>, Flux<TResponse>> delegate) {
+            Function<Flux<TRequest>, Flux<TResponse>> delegate,
+            CallOptions options) {
+
+        final int prefetch = ReactorCallOptions.getPrefetch(options);
+        final int lowTide = ReactorCallOptions.getLowTide(options);
+
         ReactorServerStreamObserverAndPublisher<TRequest> streamObserverPublisher =
-                new ReactorServerStreamObserverAndPublisher<>((ServerCallStreamObserver<TResponse>) responseObserver, null);
+                new ReactorServerStreamObserverAndPublisher<>((ServerCallStreamObserver<TResponse>) responseObserver, null, prefetch, lowTide);
 
         try {
             Flux<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(Flux.from(streamObserverPublisher)));

--- a/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
+++ b/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
@@ -51,7 +51,7 @@ public final class {{className}} {
         @java.lang.Deprecated
             {{/deprecated}}
         public {{#isManyOutput}}reactor.core.publisher.Flux{{/isManyOutput}}{{^isManyOutput}}reactor.core.publisher.Mono{{/isManyOutput}}<{{outputType}}> {{methodName}}({{#isManyInput}}reactor.core.publisher.Flux{{/isManyInput}}{{^isManyInput}}reactor.core.publisher.Mono{{/isManyInput}}<{{inputType}}> reactorRequest) {
-            return com.salesforce.reactorgrpc.stub.ClientCalls.{{reactiveCallsMethodName}}(reactorRequest, delegateStub::{{methodName}});
+            return com.salesforce.reactorgrpc.stub.ClientCalls.{{reactiveCallsMethodName}}(reactorRequest, delegateStub::{{methodName}}, getCallOptions());
         }
 
         {{/methods}}
@@ -63,7 +63,7 @@ public final class {{className}} {
         @java.lang.Deprecated
            {{/deprecated}}
         public {{#isManyOutput}}reactor.core.publisher.Flux{{/isManyOutput}}{{^isManyOutput}}reactor.core.publisher.Mono{{/isManyOutput}}<{{outputType}}> {{methodName}}({{inputType}} reactorRequest) {
-           return com.salesforce.reactorgrpc.stub.ClientCalls.{{reactiveCallsMethodName}}(reactor.core.publisher.Mono.just(reactorRequest), delegateStub::{{methodName}});
+           return com.salesforce.reactorgrpc.stub.ClientCalls.{{reactiveCallsMethodName}}(reactor.core.publisher.Mono.just(reactorRequest), delegateStub::{{methodName}}, getCallOptions());
         }
 
         {{/unaryRequestMethods}}
@@ -99,10 +99,15 @@ public final class {{className}} {
                     {{/methods}}
                     .build();
         }
+
+        protected io.grpc.CallOptions getCallOptions(int methodId) {
+            return null;
+        }
+
     }
 
     {{#methods}}
-    private static final int METHODID_{{methodNameUpperUnderscore}} = {{methodNumber}};
+    public static final int METHODID_{{methodNameUpperUnderscore}} = {{methodNumber}};
     {{/methods}}
 
     private static final class MethodHandlers<Req, Resp> implements
@@ -145,7 +150,7 @@ public final class {{className}} {
                 case METHODID_{{methodNameUpperUnderscore}}:
                     return (io.grpc.stub.StreamObserver<Req>) com.salesforce.reactorgrpc.stub.ServerCalls.{{reactiveCallsMethodName}}(
                             (io.grpc.stub.StreamObserver<{{outputType}}>) responseObserver,
-                            serviceImpl::{{methodName}});
+                            serviceImpl::{{methodName}}, serviceImpl.getCallOptions(methodId));
                 {{/isManyInput}}
                 {{/methods}}
                 default:

--- a/rx-java/README.md
+++ b/rx-java/README.md
@@ -139,6 +139,31 @@ public class RxContextPropagator {
 	}
 }
 ```
+
+## Configuration of flow control
+RX GRPC by default prefetch 512 items on client and server side. When the messages are bigger it
+can consume a lot of memory. One can override these default settings using RxCallOptions:
+
+Prefetch on client side (client consumes too slow):
+
+```java
+    RxMyAPIStub api = RxMyAPIGrpc.newRxStub(channel)
+        .withOption(RxCallOptions.CALL_OPTIONS_PREFETCH, 16)
+        .withOption(RxCallOptions.CALL_OPTIONS_LOW_TIDE, 4);
+```
+
+Prefetch on server side (server consumes too slow):
+
+```java
+    // Override getCallOptions method in your *ImplBase service class.
+    // One can use methodId to do method specific override
+    @Override
+    protected CallOptions getCallOptions(int methodId) {
+        return CallOptions.DEFAULT
+            .withOption(RxCallOptions.CALL_OPTIONS_PREFETCH, 16)
+            .withOption(RxCallOptions.CALL_OPTIONS_LOW_TIDE, 4);
+    }
+```
   
 Modules
 =======

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ClientCalls.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ClientCalls.java
@@ -7,7 +7,6 @@
 
 package com.salesforce.rxgrpc.stub;
 
-import com.salesforce.reactivegrpc.common.AbstractStreamObserverAndPublisher;
 import com.salesforce.reactivegrpc.common.BiConsumer;
 import com.salesforce.reactivegrpc.common.Function;
 import io.grpc.CallOptions;
@@ -29,20 +28,6 @@ public final class ClientCalls {
     private ClientCalls() {
 
     }
-
-    /**
-     * Sets Prefetch size of queue.
-     */
-    public static final CallOptions.Key<Integer> CALL_OPTIONS_PREFETCH =
-        CallOptions.Key.createWithDefault("reactivegrpc.internal.PREFETCH",
-            Integer.valueOf(AbstractStreamObserverAndPublisher.DEFAULT_CHUNK_SIZE));
-
-    /**
-     * Sets Low Tide of prefetch queue.
-     */
-    public static final CallOptions.Key<Integer> CALL_OPTIONS_LOW_TIDE =
-        CallOptions.Key.createWithDefault("reactivegrpc.internal.LOW_TIDE",
-            Integer.valueOf(AbstractStreamObserverAndPublisher.TWO_THIRDS_OF_DEFAULT_CHUNK_SIZE));
 
     /**
      * Implements a unary → unary call using {@link Single} → {@link Single}.
@@ -103,8 +88,8 @@ public final class ClientCalls {
             final CallOptions options) {
         try {
 
-            final int prefetch = options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
-            final int lowTide = getLowTide(options, prefetch);
+            final int prefetch = RxCallOptions.getPrefetch(options);
+            final int lowTide = RxCallOptions.getLowTide(options);
 
             return rxRequest
                     .flatMapPublisher(new io.reactivex.functions.Function<TRequest, Publisher<? extends TResponse>>() {
@@ -169,8 +154,8 @@ public final class ClientCalls {
             final Function<StreamObserver<TResponse>, StreamObserver<TRequest>> delegate,
             final CallOptions options) {
 
-        final int prefetch = options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
-        final int lowTide = getLowTide(options, prefetch);
+        final int prefetch = RxCallOptions.getPrefetch(options);
+        final int lowTide = RxCallOptions.getLowTide(options);
 
         try {
             final RxSubscriberAndClientProducer<TRequest> subscriberAndGRPCProducer =
@@ -198,11 +183,4 @@ public final class ClientCalls {
         }
     }
 
-    static int getLowTide(final CallOptions options, int prefetch) {
-        int lowTide = options == null ? CALL_OPTIONS_LOW_TIDE.getDefault() : options.getOption(CALL_OPTIONS_LOW_TIDE);
-        if (lowTide >= prefetch) {
-            throw new IllegalArgumentException(CALL_OPTIONS_LOW_TIDE + " must be less than " + CALL_OPTIONS_PREFETCH);
-        }
-        return lowTide;
-    }
 }

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ClientCalls.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ClientCalls.java
@@ -7,6 +7,7 @@
 
 package com.salesforce.rxgrpc.stub;
 
+import com.salesforce.reactivegrpc.common.AbstractStreamObserverAndPublisher;
 import com.salesforce.reactivegrpc.common.BiConsumer;
 import com.salesforce.reactivegrpc.common.Function;
 import io.grpc.CallOptions;
@@ -33,13 +34,15 @@ public final class ClientCalls {
      * Sets Prefetch size of queue.
      */
     public static final CallOptions.Key<Integer> CALL_OPTIONS_PREFETCH =
-        CallOptions.Key.createWithDefault("reactivegrpc.internal.PREFETCH", Integer.valueOf(512));
+        CallOptions.Key.createWithDefault("reactivegrpc.internal.PREFETCH",
+            Integer.valueOf(AbstractStreamObserverAndPublisher.DEFAULT_CHUNK_SIZE));
 
     /**
      * Sets Low Tide of prefetch queue.
      */
     public static final CallOptions.Key<Integer> CALL_OPTIONS_LOW_TIDE =
-        CallOptions.Key.createWithDefault("reactivegrpc.internal.LOW_TIDE", Integer.valueOf(512 * 2 / 3));
+        CallOptions.Key.createWithDefault("reactivegrpc.internal.LOW_TIDE",
+            Integer.valueOf(AbstractStreamObserverAndPublisher.TWO_THIRDS_OF_DEFAULT_CHUNK_SIZE));
 
     /**
      * Implements a unary → unary call using {@link Single} → {@link Single}.
@@ -195,7 +198,7 @@ public final class ClientCalls {
         }
     }
 
-    private static int getLowTide(final CallOptions options, int prefetch) {
+    static int getLowTide(final CallOptions options, int prefetch) {
         int lowTide = options == null ? CALL_OPTIONS_LOW_TIDE.getDefault() : options.getOption(CALL_OPTIONS_LOW_TIDE);
         if (lowTide >= prefetch) {
             throw new IllegalArgumentException(CALL_OPTIONS_LOW_TIDE + " must be less than " + CALL_OPTIONS_PREFETCH);

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ClientCalls.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ClientCalls.java
@@ -100,8 +100,8 @@ public final class ClientCalls {
             final CallOptions options) {
         try {
 
-            int prefetch = options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
-            int lowTide = getLowTide(options, prefetch);
+            final int prefetch = options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
+            final int lowTide = getLowTide(options, prefetch);
 
             return rxRequest
                     .flatMapPublisher(new io.reactivex.functions.Function<TRequest, Publisher<? extends TResponse>>() {
@@ -166,8 +166,8 @@ public final class ClientCalls {
             final Function<StreamObserver<TResponse>, StreamObserver<TRequest>> delegate,
             final CallOptions options) {
 
-        int prefetch = options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
-        int lowTide = getLowTide(options, prefetch);
+        final int prefetch = options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
+        final int lowTide = getLowTide(options, prefetch);
 
         try {
             final RxSubscriberAndClientProducer<TRequest> subscriberAndGRPCProducer =

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxCallOptions.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxCallOptions.java
@@ -11,13 +11,13 @@ import com.salesforce.reactivegrpc.common.AbstractStreamObserverAndPublisher;
 import io.grpc.CallOptions;
 
 /**
- * RX Call options
+ * RX Call options.
  */
 public final class RxCallOptions {
 
     private RxCallOptions() {
     }
-    
+
     /**
      * Sets Prefetch size of queue.
      */
@@ -32,16 +32,16 @@ public final class RxCallOptions {
         io.grpc.CallOptions.Key.createWithDefault("reactivegrpc.internal.LOW_TIDE",
             Integer.valueOf(AbstractStreamObserverAndPublisher.TWO_THIRDS_OF_DEFAULT_CHUNK_SIZE));
 
-    
+
     /**
-     * Utility function to get prefetch option 
+     * Utility function to get prefetch option.
      */
     public static int getPrefetch(final CallOptions options) {
         return options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
     }
-    
+
     /**
-     * Utility function to get low tide option together with validation
+     * Utility function to get low tide option together with validation.
      */
     public static int getLowTide(final CallOptions options) {
         int prefetch = getPrefetch(options);

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxCallOptions.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxCallOptions.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2019, Salesforce.com, Inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.rxgrpc.stub;
+
+import com.salesforce.reactivegrpc.common.AbstractStreamObserverAndPublisher;
+import io.grpc.CallOptions;
+
+/**
+ * RX Call options
+ */
+public final class RxCallOptions {
+
+    private RxCallOptions() {
+    }
+    
+    /**
+     * Sets Prefetch size of queue.
+     */
+    public static final io.grpc.CallOptions.Key<Integer> CALL_OPTIONS_PREFETCH =
+        io.grpc.CallOptions.Key.createWithDefault("reactivegrpc.internal.PREFETCH",
+            Integer.valueOf(AbstractStreamObserverAndPublisher.DEFAULT_CHUNK_SIZE));
+
+    /**
+     * Sets Low Tide of prefetch queue.
+     */
+    public static final io.grpc.CallOptions.Key<Integer> CALL_OPTIONS_LOW_TIDE =
+        io.grpc.CallOptions.Key.createWithDefault("reactivegrpc.internal.LOW_TIDE",
+            Integer.valueOf(AbstractStreamObserverAndPublisher.TWO_THIRDS_OF_DEFAULT_CHUNK_SIZE));
+
+    
+    /**
+     * Utility function to get prefetch option 
+     */
+    public static int getPrefetch(final CallOptions options) {
+        return options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
+    }
+    
+    /**
+     * Utility function to get low tide option together with validation
+     */
+    public static int getLowTide(final CallOptions options) {
+        int prefetch = getPrefetch(options);
+        int lowTide = options == null ? CALL_OPTIONS_LOW_TIDE.getDefault() : options.getOption(CALL_OPTIONS_LOW_TIDE);
+        if (lowTide >= prefetch) {
+            throw new IllegalArgumentException(CALL_OPTIONS_LOW_TIDE + " must be less than " + CALL_OPTIONS_PREFETCH);
+        }
+        return lowTide;
+    }
+
+}

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxClientStreamObserverAndPublisher.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxClientStreamObserverAndPublisher.java
@@ -32,6 +32,14 @@ class RxClientStreamObserverAndPublisher<T>
         super(new SimpleQueueAdapter<T>(new SpscArrayQueue<T>(DEFAULT_CHUNK_SIZE)), onSubscribe, onTerminate);
     }
 
+    RxClientStreamObserverAndPublisher(
+            Consumer<CallStreamObserver<?>> onSubscribe,
+            Runnable onTerminate,
+            int prefetch,
+            int lowTide) {
+        super(new SimpleQueueAdapter<T>(new SpscArrayQueue<T>(prefetch)), onSubscribe, onTerminate, prefetch, lowTide);
+    }
+
     @Override
     public int requestFusion(int requestedMode) {
         if ((requestedMode & QueueFuseable.ASYNC) != 0) {

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxClientStreamObserverAndPublisher.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxClientStreamObserverAndPublisher.java
@@ -22,10 +22,6 @@ class RxClientStreamObserverAndPublisher<T>
         extends AbstractClientStreamObserverAndPublisher<T>
         implements QueueSubscription<T> {
 
-    RxClientStreamObserverAndPublisher(Consumer<CallStreamObserver<?>> onSubscribe) {
-        super(new SimpleQueueAdapter<T>(new SpscArrayQueue<T>(DEFAULT_CHUNK_SIZE)), onSubscribe);
-    }
-
     RxClientStreamObserverAndPublisher(
             Consumer<CallStreamObserver<?>> onSubscribe,
             Runnable onTerminate) {

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxServerStreamObserverAndPublisher.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/RxServerStreamObserverAndPublisher.java
@@ -25,8 +25,10 @@ class RxServerStreamObserverAndPublisher<T>
 
     RxServerStreamObserverAndPublisher(
             ServerCallStreamObserver<?> serverCallStreamObserver,
-            Consumer<CallStreamObserver<?>> onSubscribe) {
-        super(serverCallStreamObserver, new SimpleQueueAdapter<T>(new SpscArrayQueue<T>(DEFAULT_CHUNK_SIZE)), onSubscribe);
+            Consumer<CallStreamObserver<?>> onSubscribe,
+            int prefetch,
+            int lowTide) {
+        super(serverCallStreamObserver, new SimpleQueueAdapter<T>(new SpscArrayQueue<T>(prefetch)), onSubscribe, prefetch, lowTide);
     }
 
     @Override

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
@@ -89,7 +89,7 @@ public final class ServerCalls {
     public static <TRequest, TResponse> StreamObserver<TRequest> manyToOne(
             final StreamObserver<TResponse> responseObserver,
             final Function<Flowable<TRequest>, Single<TResponse>> delegate,
-            int prefetch, int lowTide) {
+            final int prefetch, final int lowTide) {
 
         if (lowTide >= prefetch) {
             throw new IllegalArgumentException("lowTide must be less than prefetch");
@@ -136,7 +136,7 @@ public final class ServerCalls {
     public static <TRequest, TResponse> StreamObserver<TRequest> manyToMany(
             final StreamObserver<TResponse> responseObserver,
             final Function<Flowable<TRequest>, Flowable<TResponse>> delegate,
-            int prefetch, int lowTide) {
+            final int prefetch, final int lowTide) {
 
         if (lowTide >= prefetch) {
             throw new IllegalArgumentException("lowTide must be less than prefetch");

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
@@ -30,16 +30,6 @@ public final class ServerCalls {
     }
 
     /**
-     * Sets Prefetch size of queue.
-     */
-    public static final CallOptions.Key<Integer> CALL_OPTIONS_PREFETCH = ClientCalls.CALL_OPTIONS_PREFETCH;
-
-    /**
-     * Sets Low Tide of prefetch queue.
-     */
-    public static final CallOptions.Key<Integer> CALL_OPTIONS_LOW_TIDE = ClientCalls.CALL_OPTIONS_LOW_TIDE;
-
-    /**
      * Implements a unary → unary call using {@link Single} → {@link Single}.
      */
     public static <TRequest, TResponse> void oneToOne(
@@ -102,8 +92,8 @@ public final class ServerCalls {
             final Function<Flowable<TRequest>, Single<TResponse>> delegate,
             final CallOptions options) {
 
-        final int prefetch = options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
-        final int lowTide = ClientCalls.getLowTide(options, prefetch);
+        final int prefetch = RxCallOptions.getPrefetch(options);
+        final int lowTide = RxCallOptions.getLowTide(options);
 
         final RxServerStreamObserverAndPublisher<TRequest> streamObserverPublisher =
                 new RxServerStreamObserverAndPublisher<TRequest>((ServerCallStreamObserver<TResponse>) responseObserver, null, prefetch, lowTide);
@@ -148,8 +138,8 @@ public final class ServerCalls {
             final Function<Flowable<TRequest>, Flowable<TResponse>> delegate,
             final CallOptions options) {
 
-        final int prefetch = options == null ? CALL_OPTIONS_PREFETCH.getDefault() : options.getOption(CALL_OPTIONS_PREFETCH);
-        final int lowTide = ClientCalls.getLowTide(options, prefetch);
+        final int prefetch = RxCallOptions.getPrefetch(options);
+        final int lowTide = RxCallOptions.getLowTide(options);
 
         final RxServerStreamObserverAndPublisher<TRequest> streamObserverPublisher =
                 new RxServerStreamObserverAndPublisher<TRequest>((ServerCallStreamObserver<TResponse>) responseObserver, null, prefetch, lowTide);

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
@@ -90,7 +90,7 @@ public final class ServerCalls {
             final StreamObserver<TResponse> responseObserver,
             final Function<Flowable<TRequest>, Single<TResponse>> delegate,
             int prefetch, int lowTide) {
-        
+
         if (lowTide >= prefetch) {
             throw new IllegalArgumentException("lowTide must be less than prefetch");
         }
@@ -137,7 +137,7 @@ public final class ServerCalls {
             final StreamObserver<TResponse> responseObserver,
             final Function<Flowable<TRequest>, Flowable<TResponse>> delegate,
             int prefetch, int lowTide) {
-        
+
         if (lowTide >= prefetch) {
             throw new IllegalArgumentException("lowTide must be less than prefetch");
         }

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
@@ -88,9 +88,15 @@ public final class ServerCalls {
      */
     public static <TRequest, TResponse> StreamObserver<TRequest> manyToOne(
             final StreamObserver<TResponse> responseObserver,
-            final Function<Flowable<TRequest>, Single<TResponse>> delegate) {
+            final Function<Flowable<TRequest>, Single<TResponse>> delegate,
+            int prefetch, int lowTide) {
+        
+        if (lowTide >= prefetch) {
+            throw new IllegalArgumentException("lowTide must be less than prefetch");
+        }
+
         final RxServerStreamObserverAndPublisher<TRequest> streamObserverPublisher =
-                new RxServerStreamObserverAndPublisher<TRequest>((ServerCallStreamObserver<TResponse>) responseObserver, null);
+                new RxServerStreamObserverAndPublisher<TRequest>((ServerCallStreamObserver<TResponse>) responseObserver, null, prefetch, lowTide);
 
         try {
             final Single<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(Flowable.fromPublisher(streamObserverPublisher)));
@@ -129,9 +135,15 @@ public final class ServerCalls {
      */
     public static <TRequest, TResponse> StreamObserver<TRequest> manyToMany(
             final StreamObserver<TResponse> responseObserver,
-            final Function<Flowable<TRequest>, Flowable<TResponse>> delegate) {
+            final Function<Flowable<TRequest>, Flowable<TResponse>> delegate,
+            int prefetch, int lowTide) {
+        
+        if (lowTide >= prefetch) {
+            throw new IllegalArgumentException("lowTide must be less than prefetch");
+        }
+
         final RxServerStreamObserverAndPublisher<TRequest> streamObserverPublisher =
-                new RxServerStreamObserverAndPublisher<TRequest>((ServerCallStreamObserver<TResponse>) responseObserver, null);
+                new RxServerStreamObserverAndPublisher<TRequest>((ServerCallStreamObserver<TResponse>) responseObserver, null, prefetch, lowTide);
 
         try {
             final Flowable<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(Flowable.fromPublisher(streamObserverPublisher)));

--- a/rx-java/rxgrpc/src/main/resources/RxStub.mustache
+++ b/rx-java/rxgrpc/src/main/resources/RxStub.mustache
@@ -58,7 +58,7 @@ public final class {{className}} {
                     public void accept({{inputType}} request, io.grpc.stub.StreamObserver<{{outputType}}> observer) {
                         delegateStub.{{methodNameCamelCase}}(request, observer);
                     }
-                });
+                }, getCallOptions());
             {{/isManyInput}}
             {{#isManyInput}}
                 new com.salesforce.reactivegrpc.common.Function<io.grpc.stub.StreamObserver<{{outputType}}>, io.grpc.stub.StreamObserver<{{inputType}}>>() {
@@ -66,7 +66,7 @@ public final class {{className}} {
                     public io.grpc.stub.StreamObserver<{{inputType}}> apply(io.grpc.stub.StreamObserver<{{outputType}}> observer) {
                         return delegateStub.{{methodNameCamelCase}}(observer);
                     }
-                });
+                }, getCallOptions());
             {{/isManyInput}}
         }
 
@@ -85,7 +85,7 @@ public final class {{className}} {
                     public void accept({{inputType}} request, io.grpc.stub.StreamObserver<{{outputType}}> observer) {
                         delegateStub.{{methodNameCamelCase}}(request, observer);
                     }
-                });
+                }, getCallOptions());
         }
 
         {{/unaryRequestMethods}}
@@ -121,6 +121,15 @@ public final class {{className}} {
                     {{/methods}}
                     .build();
         }
+        
+        public int getPrefetch(int methodId) {
+            return 512;
+        }
+        
+        public int getLowTide(int methodId) {
+            return 512 * 2 / 3;
+        }
+        
     }
 
     {{#methods}}
@@ -172,7 +181,7 @@ public final class {{className}} {
                 case METHODID_{{methodNameUpperUnderscore}}:
                     return (io.grpc.stub.StreamObserver<Req>) com.salesforce.rxgrpc.stub.ServerCalls.{{reactiveCallsMethodName}}(
                             (io.grpc.stub.StreamObserver<{{outputType}}>) responseObserver,
-                            serviceImpl::{{methodNameCamelCase}});
+                            serviceImpl::{{methodNameCamelCase}}, serviceImpl.getPrefetch(methodId), serviceImpl.getLowTide(methodId));
                 {{/isManyInput}}
                 {{/methods}}
                 default:

--- a/rx-java/rxgrpc/src/main/resources/RxStub.mustache
+++ b/rx-java/rxgrpc/src/main/resources/RxStub.mustache
@@ -121,19 +121,15 @@ public final class {{className}} {
                     {{/methods}}
                     .build();
         }
-        
-        public int getPrefetch(int methodId) {
-            return 512;
+
+        protected io.grpc.CallOptions getCallOptions(int methodId) {
+            return null;
         }
-        
-        public int getLowTide(int methodId) {
-            return 512 * 2 / 3;
-        }
-        
+
     }
 
     {{#methods}}
-    private static final int METHODID_{{methodNameUpperUnderscore}} = {{methodNumber}};
+    public static final int METHODID_{{methodNameUpperUnderscore}} = {{methodNumber}};
     {{/methods}}
 
     private static final class MethodHandlers<Req, Resp> implements
@@ -181,7 +177,7 @@ public final class {{className}} {
                 case METHODID_{{methodNameUpperUnderscore}}:
                     return (io.grpc.stub.StreamObserver<Req>) com.salesforce.rxgrpc.stub.ServerCalls.{{reactiveCallsMethodName}}(
                             (io.grpc.stub.StreamObserver<{{outputType}}>) responseObserver,
-                            serviceImpl::{{methodNameCamelCase}}, serviceImpl.getPrefetch(methodId), serviceImpl.getLowTide(methodId));
+                            serviceImpl::{{methodNameCamelCase}}, serviceImpl.getCallOptions(methodId));
                 {{/isManyInput}}
                 {{/methods}}
                 default:


### PR DESCRIPTION
Default Flowable behavior on Client and Server sending side is to send messages into the queue with length 512. When there is too many concurrent calls and when messages are quite big it can cause OOM. This pull requests allows to override these for such RPC calls.

Client example:
```
        RxNassStub api = RxNassGrpc.newRxStub(channel)
            .withOption(ClientCalls.CALL_OPTIONS_PREFETCH, 16)
            .withOption(ClientCalls.CALL_OPTIONS_LOW_TIDE, 4);
```
Server example:
```
public class TestingService extends NassImplBase {

    @Override
    public int getLowTide(int methodId) {
        return 4;
    }

    @Override
    public int getPrefetch(int methodId) {
        return 8;
    }
```
