### PR TITLE
Be consistent when using Flux mutualization ops.

### DIFF
--- a/reactor/README.md
+++ b/reactor/README.md
@@ -91,12 +91,12 @@ After installing the plugin, Reactor-gRPC service stubs will be generated along 
 
 ## Don't break the chain
 Used on their own, the generated Reactor stub methods do not cleanly chain with other Reactor operators.
-Using the `compose()` and `as()` methods of `Mono` and `Flux` are preferred over direct invocation.
+Using the `transform()` and `as()` methods of `Mono` and `Flux` are preferred over direct invocation.
 
 #### One→One, Many→Many
 ```java
-Mono<HelloResponse> monoResponse = monoRequest.compose(stub::sayHello);
-Flux<HelloResponse> fluxResponse = fluxRequest.compose(stub::sayHelloBothStream);
+Mono<HelloResponse> monoResponse = monoRequest.transform(stub::sayHello);
+Flux<HelloResponse> fluxResponse = fluxRequest.transform(stub::sayHelloBothStream);
 ```
 
 #### One→Many, Many→One

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ConcurrentRequestIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ConcurrentRequestIntegrationTest.java
@@ -81,7 +81,7 @@ public class ConcurrentRequestIntegrationTest {
         // == MAKE REQUESTS ==
         // One to One
         Mono<HelloRequest> req1 = Mono.just(HelloRequest.newBuilder().setName("reactorjava").build());
-        Mono<HelloResponse> resp1 = req1.compose(stub::sayHello);
+        Mono<HelloResponse> resp1 = req1.transform(stub::sayHello);
 
         // One to Many
         Mono<HelloRequest> req2 = Mono.just(HelloRequest.newBuilder().setName("reactorjava").build());

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ContextPropagationIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ContextPropagationIntegrationTest.java
@@ -137,7 +137,7 @@ public class ContextPropagationIntegrationTest {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
         Context.current()
                 .withValue(ctxKey, "ClientSendsContext")
-                .run(() -> StepVerifier.create(worldReq.compose(stub::sayHello).map(HelloResponse::getMessage))
+                .run(() -> StepVerifier.create(worldReq.transform(stub::sayHello).map(HelloResponse::getMessage))
                         .expectNext("Hello World")
                         .verifyComplete());
 
@@ -148,7 +148,7 @@ public class ContextPropagationIntegrationTest {
     public void ClientGetsContext() {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
 
-        Mono<HelloResponse> test = worldReq.compose(stub::sayHello)
+        Mono<HelloResponse> test = worldReq.transform(stub::sayHello)
                 .doOnSuccess(resp -> {
                     Context ctx = Context.current();
                     assertThat(ctxKey.get(ctx)).isEqualTo("ClientGetsContext");
@@ -163,7 +163,7 @@ public class ContextPropagationIntegrationTest {
     public void ServerAcceptsContext() {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
 
-        StepVerifier.create(worldReq.compose(stub::sayHello).map(HelloResponse::getMessage))
+        StepVerifier.create(worldReq.transform(stub::sayHello).map(HelloResponse::getMessage))
                 .expectNext("Hello World")
                 .verifyComplete();
         assertThat(svc.getReceivedCtxValue()).isEqualTo("ServerAcceptsContext");

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/EndToEndIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/EndToEndIntegrationTest.java
@@ -68,7 +68,7 @@ public class EndToEndIntegrationTest {
     public void oneToOne() throws IOException {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
         Mono<HelloRequest> req = Mono.just(HelloRequest.newBuilder().setName("reactorjava").build());
-        Mono<HelloResponse> resp = req.compose(stub::sayHello);
+        Mono<HelloResponse> resp = req.transform(stub::sayHello);
 
         StepVerifier.create(resp.map(HelloResponse::getMessage))
                 .expectNext("Hello reactorjava")

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ReactiveClientStandardServerInteropTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ReactiveClientStandardServerInteropTest.java
@@ -122,7 +122,7 @@ public class ReactiveClientStandardServerInteropTest {
     public void oneToOne() {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
         Mono<String> reactorRequest = Mono.just("World");
-        Mono<String> reactorResponse = reactorRequest.map(this::toRequest).compose(stub::sayHello).map(this::fromResponse);
+        Mono<String> reactorResponse = reactorRequest.map(this::toRequest).transform(stub::sayHello).map(this::fromResponse);
 
         StepVerifier.create(reactorResponse)
                 .expectNext("Hello World")
@@ -155,7 +155,7 @@ public class ReactiveClientStandardServerInteropTest {
     public void manyToMany() {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
         Flux<String> reactorRequest = Flux.just("A", "B", "C", "D");
-        Flux<String> reactorResponse = reactorRequest.map(this::toRequest).compose(stub::sayHelloBothStream).map(this::fromResponse);
+        Flux<String> reactorResponse = reactorRequest.map(this::toRequest).transform(stub::sayHelloBothStream).map(this::fromResponse);
 
         StepVerifier.create(reactorResponse)
                 .expectNext("Hello A and B", "Hello C and D")

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ServerErrorIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/ServerErrorIntegrationTest.java
@@ -67,7 +67,7 @@ public class ServerErrorIntegrationTest {
     @Test
     public void oneToOne() {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
-        Mono<HelloResponse> resp = Mono.just(HelloRequest.getDefaultInstance()).compose(stub::sayHello);
+        Mono<HelloResponse> resp = Mono.just(HelloRequest.getDefaultInstance()).transform(stub::sayHello);
 
         StepVerifier.create(resp)
                 .verifyErrorMatches(t -> t instanceof StatusRuntimeException && ((StatusRuntimeException)t).getStatus() == Status.INTERNAL);

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/UnaryZeroMessageResponseIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/UnaryZeroMessageResponseIntegrationTest.java
@@ -65,7 +65,7 @@ public class UnaryZeroMessageResponseIntegrationTest {
 
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(serverRule.getChannel());
         Mono<HelloRequest> req = Mono.just(HelloRequest.newBuilder().setName("reactor").build());
-        Mono<HelloResponse> resp = req.compose(stub::sayHello);
+        Mono<HelloResponse> resp = req.transform(stub::sayHello);
 
         StepVerifier.create(resp).verifyErrorMatches(t ->
                 t instanceof StatusRuntimeException &&
@@ -95,7 +95,7 @@ public class UnaryZeroMessageResponseIntegrationTest {
 
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(serverRule.getChannel());
         Mono<HelloRequest> req = Mono.just(HelloRequest.newBuilder().setName("reactor").build());
-        Mono<HelloResponse> resp = req.compose(stub::sayHello);
+        Mono<HelloResponse> resp = req.transform(stub::sayHello);
 
         StepVerifier.create(resp).verifyErrorMatches(t ->
                 t instanceof StatusRuntimeException &&

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/UnexpectedServerErrorIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/UnexpectedServerErrorIntegrationTest.java
@@ -77,7 +77,7 @@ public class UnexpectedServerErrorIntegrationTest {
     @Test
     public void oneToOne() {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
-        Mono<HelloResponse> resp = Mono.just(HelloRequest.getDefaultInstance()).compose(stub::sayHello);
+        Mono<HelloResponse> resp = Mono.just(HelloRequest.getDefaultInstance()).transform(stub::sayHello);
 
         StepVerifier.create(resp)
                 .verifyErrorMatches(t -> t instanceof StatusRuntimeException && ((StatusRuntimeException)t).getStatus().getCode() == Status.Code.INTERNAL);
@@ -111,7 +111,7 @@ public class UnexpectedServerErrorIntegrationTest {
     public void manyToMany() {
         ReactorGreeterGrpc.ReactorGreeterStub stub = ReactorGreeterGrpc.newReactorStub(channel);
         Flux<HelloRequest> req = Flux.just(HelloRequest.getDefaultInstance());
-        Flux<HelloResponse> resp = req.compose(stub::sayHelloBothStream);
+        Flux<HelloResponse> resp = req.transform(stub::sayHelloBothStream);
 
         StepVerifier.create(resp)
                 .verifyErrorMatches(t -> t instanceof StatusRuntimeException && ((StatusRuntimeException)t).getStatus().getCode() == Status.Code.INTERNAL);


### PR DESCRIPTION
Flux mutualization operators have different "binding" times. Since Reactive-gRPC stubs don't make dynamic decisions about how to transform a stream, use the greedy transform() function instead of the lazy compose() function.

Fixes #203