### PR TITLE
Feature/upgrade reactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <module>reactor/reactor-grpc</module>
         <module>reactor/reactor-grpc-stub</module>
         <module>reactor/reactor-grpc-retry</module>
+        <module>reactor/reactor-grpc-retry-pre3.3.9</module>
         <module>reactor/reactor-grpc-tck</module>
         <module>reactor/reactor-grpc-test</module>
         <module>reactor/reactor-grpc-test-32</module>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <module>rx-java/rxgrpc-test</module>
         <module>reactor/reactor-grpc</module>
         <module>reactor/reactor-grpc-stub</module>
+        <module>reactor/reactor-grpc-retry</module>
         <module>reactor/reactor-grpc-tck</module>
         <module>reactor/reactor-grpc-test</module>
         <module>reactor/reactor-grpc-test-32</module>
@@ -65,8 +66,9 @@
         <grpc.version>1.37.0</grpc.version>
         <protoc.version>3.15.8</protoc.version> <!-- Same version as grpc-proto -->
         <jprotoc.version>1.1.0</jprotoc.version>
+
         <rxjava.version>2.2.21</rxjava.version>
-        <reactor.version>3.2.12.RELEASE</reactor.version>
+        <reactor.version>3.4.7</reactor.version>
 
         <!-- Test Dependency Versions -->
         <grpc.contrib.version>0.8.1</grpc.contrib.version>

--- a/reactor/README.md
+++ b/reactor/README.md
@@ -140,7 +140,7 @@ retry, the upstream rx pipeline is re-subscribed to acquire a request message an
 rx pipeline never sees the error.
 
 ```java
-Flux<HelloResponse> fluxResponse = fluxRequest.compose(GrpcRetry.ManyToMany.retry(stub::sayHelloBothStream));
+Flux<HelloResponse> fluxResponse = fluxRequest.transformDeferred(GrpcRetry.ManyToMany.retry(stub::sayHelloBothStream));
 ```
 
 For complex retry scenarios, use the `Retry` builder from <a href="https://github.com/reactor/reactor-addons/blob/master/reactor-extra/src/main/java/reactor/retry/Retry.java">Reactor Extras</a>.

--- a/reactor/README.md
+++ b/reactor/README.md
@@ -145,6 +145,10 @@ Flux<HelloResponse> fluxResponse = fluxRequest.transformDeferred(GrpcRetry.ManyT
 
 For complex retry scenarios, use the `Retry` builder from <a href="https://github.com/reactor/reactor-addons/blob/master/reactor-extra/src/main/java/reactor/retry/Retry.java">Reactor Extras</a>.
 
+Due to breaking changes to the Flux retry API introduced in Reactor 3.3.9 (Semver fail!), the Retry class has been moved
+to either the `reactor-grpc-retry` or `reactor-grpc-retry-pre3.3.9` maven modules. You must select the correct module
+for your version.
+
 ## gRPC Context propagation
 Reactor does not have a convenient mechanism for passing the `ThreadLocal` gRPC `Context` between threads in a reactive
 call chain. If you never use `observeOn()` or `subscribeOn()` the gRPC context _should_ propagate correctly. However,
@@ -189,5 +193,7 @@ Reactor-gRPC is broken down into four sub-modules:
 
 * _reactor-grpc_ - a protoc generator for generating gRPC bindings for Reactor.
 * _reactor-grpc-stub_ - stub classes supporting the generated Reactor bindings.
+* _reactor-grpc-retry_ - class for retrying requests.
+* _reactor-grpc-retry-pre3.3.9_ - class for retrying requests for Reactor versions <= 3.3.8.
 * _reactor-grpc-test_ - integration tests for Reactor.
 * _reactor-grpc-tck_ - Reactive Streams TCK compliance tests for Reactor.

--- a/reactor/reactor-grpc-retry-pre3.3.9/pom.xml
+++ b/reactor/reactor-grpc-retry-pre3.3.9/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright (c) 2019, Salesforce.com, Inc.
+  ~  All rights reserved.
+  ~  Licensed under the BSD 3-Clause license.
+  ~  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>reactive-grpc</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>reactor-grpc-retry-pre3.3.9</artifactId>
+
+    <properties>
+        <old.reactor.version>3.3.8.RELEASE</old.reactor.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>reactive-grpc-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>${old.reactor.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>${old.reactor.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.addons</groupId>
+            <artifactId>reactor-extra</artifactId>
+            <version>${reactor.extra.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <configLocation>../../checkstyle.xml</configLocation>
+                    <suppressionsLocation>../../checkstyle_ignore.xml</suppressionsLocation>
+                </configuration>
+            </plugin>
+
+            <!-- Jar and Bundle plugin used for OSGI support -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.2</version>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/reactor/reactor-grpc-retry-pre3.3.9/src/main/java/com/salesforce/reactorgrpc/retry/GrpcRetry.java
+++ b/reactor/reactor-grpc-retry-pre3.3.9/src/main/java/com/salesforce/reactorgrpc/retry/GrpcRetry.java
@@ -1,0 +1,169 @@
+/*
+ *  Copyright (c) 2019, Salesforce.com, Inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.reactorgrpc.retry;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+/**
+ * {@code GrpcRetry} is used to transparently re-establish a streaming gRPC request in the event of a server error.
+ * <p>
+ * During a retry, the upstream rx pipeline is re-subscribed to acquire a request message and the RPC call re-issued.
+ * The downstream rx pipeline never sees the error.
+ */
+public final class GrpcRetry {
+    private GrpcRetry() { }
+
+    /**
+     * {@link GrpcRetry} functions for streaming response gRPC operations.
+     */
+    public static final class OneToMany {
+        private OneToMany() {
+        }
+
+        /**
+         * Retries a streaming gRPC call, using the same semantics as {@link Flux#retryWhen(Function)}.
+         *
+         * For easier use, use the Retry builder from
+         * <a href="https://github.com/reactor/reactor-addons/blob/master/reactor-extra/src/main/java/reactor/retry/Retry.java">Reactor Extras</a>.
+         *
+         * @param operation the gRPC operation to retry, typically from a generated reactive-grpc stub class
+         * @param whenFactory receives a Publisher of notifications with which a user can complete or error, aborting the retry
+         * @param <I> I
+         * @param <O> O
+         *
+         * @see Flux#retryWhen(Function)
+         */
+        public static <I, O> Function<? super Mono<I>, Flux<O>> retryWhen(final Function<Mono<I>, Flux<O>> operation, final Function<Flux<Throwable>, ? extends Publisher<?>> whenFactory) {
+            return request -> Flux.defer(() -> operation.apply(request)).retryWhen(whenFactory);
+        }
+
+        /**
+         * Retries a streaming gRPC call with a fixed delay between retries.
+         *
+         * @param operation the gRPC operation to retry, typically from a generated reactive-grpc stub class
+         * @param delay the delay between retries
+         * @param <I> I
+         * @param <O> O
+         */
+        public static <I, O> Function<? super Mono<I>, Flux<O>> retryAfter(final Function<Mono<I>, Flux<O>> operation, final Duration delay) {
+            return retryWhen(operation, errors -> errors.delayElements(delay));
+        }
+
+        /**
+         * Retries a streaming gRPC call immediately.
+         *
+         * @param operation the gRPC operation to retry, typically from a generated reactive-grpc stub class
+         * @param <I> I
+         * @param <O> O
+         */
+        public static <I, O> Function<? super Mono<I>, Flux<O>> retryImmediately(final Function<Mono<I>, Flux<O>> operation) {
+            return retryWhen(operation, errors -> errors);
+        }
+    }
+
+    /**
+     * {@link GrpcRetry} functions for bi-directional streaming gRPC operations.
+     */
+    public static final class ManyToMany {
+        private ManyToMany() {
+        }
+
+        /**
+         * Retries a streaming gRPC call, using the same semantics as {@link Flux#retryWhen(Function)}.
+         *
+         * For easier use, use the Retry builder from
+         * <a href="https://github.com/reactor/reactor-addons/blob/master/reactor-extra/src/main/java/reactor/retry/Retry.java">Reactor Extras</a>.
+         *
+         * @param operation the gRPC operation to retry, typically from a generated reactive-grpc stub class
+         * @param whenFactory receives a Publisher of notifications with which a user can complete or error, aborting the retry
+         * @param <I> I
+         * @param <O> O
+         *
+         * @see Flux#retryWhen(Function)
+         */
+        public static <I, O> Function<? super Flux<I>, ? extends Publisher<O>> retryWhen(final Function<Flux<I>, Flux<O>> operation, final Function<Flux<Throwable>, ? extends Publisher<?>> whenFactory) {
+            return request -> Flux.defer(() -> operation.apply(request)).retryWhen(whenFactory);
+        }
+
+        /**
+         * Retries a streaming gRPC call with a fixed delay between retries.
+         *
+         * @param operation the gRPC operation to retry, typically from a generated reactive-grpc stub class
+         * @param delay the delay between retries
+         * @param <I> I
+         * @param <O> O
+         */
+        public static <I, O> Function<? super Flux<I>, ? extends Publisher<O>> retryAfter(final Function<Flux<I>, Flux<O>> operation, final Duration delay) {
+            return retryWhen(operation, errors -> errors.delayElements(delay));
+        }
+
+        /**
+         * Retries a streaming gRPC call immediately.
+         *
+         * @param operation the gRPC operation to retry, typically from a generated reactive-grpc stub class
+         * @param <I> I
+         * @param <O> O
+         */
+        public static <I, O> Function<? super Flux<I>, ? extends Publisher<O>> retryImmediately(final Function<Flux<I>, Flux<O>> operation) {
+            return retryWhen(operation, errors -> errors);
+        }
+    }
+
+    /**
+     * {@link GrpcRetry} functions for streaming request gRPC operations.
+     */
+    public static final class ManyToOne {
+        private ManyToOne() {
+        }
+
+        /**
+         * Retries a streaming gRPC call, using the same semantics as {@link Flux#retryWhen(Function)}.
+         *
+         * For easier use, use the Retry builder from
+         * <a href="https://github.com/reactor/reactor-addons/blob/master/reactor-extra/src/main/java/reactor/retry/Retry.java">Reactor Extras</a>.
+         *
+         * @param operation the gRPC operation to retry, typically from a generated reactive-grpc stub class
+         * @param whenFactory receives a Publisher of notifications with which a user can complete or error, aborting the retry
+         * @param <I> I
+         * @param <O> O
+         *
+         * @see Flux#retryWhen(Function)
+         */
+        public static <I, O> Function<? super Flux<I>, Mono<O>> retryWhen(final Function<Flux<I>, Mono<O>> operation, final Function<Flux<Throwable>, ? extends Publisher<?>> whenFactory) {
+            return request -> Mono.defer(() -> operation.apply(request)).retryWhen(whenFactory);
+        }
+
+        /**
+         * Retries a streaming gRPC call with a fixed delay between retries.
+         *
+         * @param operation the gRPC operation to retry, typically from a generated reactive-grpc stub class
+         * @param delay the delay between retries
+         * @param <I> I
+         * @param <O> O
+         */
+        public static <I, O> Function<? super Flux<I>, Mono<O>> retryAfter(final Function<Flux<I>, Mono<O>> operation, final Duration delay) {
+            return retryWhen(operation, errors -> errors.delayElements(delay));
+        }
+
+        /**
+         * Retries a streaming gRPC call immediately.
+         *
+         * @param operation the gRPC operation to retry, typically from a generated reactive-grpc stub class
+         * @param <I> I
+         * @param <O> O
+         */
+        public static <I, O> Function<? super Flux<I>, Mono<O>> retryImmediately(final Function<Flux<I>, Mono<O>> operation) {
+            return retryWhen(operation, errors -> errors);
+        }
+    }
+}

--- a/reactor/reactor-grpc-retry-pre3.3.9/src/test/java/com/salesforce/reactorgrpc/retry/GrpcRetryTest.java
+++ b/reactor/reactor-grpc-retry-pre3.3.9/src/test/java/com/salesforce/reactorgrpc/retry/GrpcRetryTest.java
@@ -1,0 +1,172 @@
+/*  Copyright (c) 2019, Salesforce.com, Inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.reactorgrpc.retry;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoSink;
+import reactor.retry.Retry;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@SuppressWarnings("Duplicates")
+public class GrpcRetryTest {
+    private Flux<Integer> newThreeErrorFlux() {
+        return Flux.create(new Consumer<FluxSink<Integer>>() {
+            int count = 3;
+            @Override
+            public void accept(FluxSink<Integer> emitter) {
+                if (count > 0) {
+                    emitter.error(new Throwable("Not yet!"));
+                    count--;
+                } else {
+                    emitter.next(0);
+                    emitter.complete();
+                }
+            }
+        }, FluxSink.OverflowStrategy.BUFFER);
+    }
+
+    private Mono<Integer> newThreeErrorMono() {
+        return Mono.create(new Consumer<MonoSink<Integer>>() {
+            int count = 3;
+            @Override
+            public void accept(MonoSink<Integer> emitter){
+                if (count > 0) {
+                    emitter.error(new Throwable("Not yet!"));
+                    count--;
+                } else {
+                    emitter.success(0);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void noRetryMakesErrorFlowabable() {
+        Flux<Integer> test = newThreeErrorFlux()
+                .as(flux -> flux);
+
+        StepVerifier.create(test)
+                .expectErrorMessage("Not yet!")
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void noRetryMakesErrorSingle() {
+        Mono<Integer> test = newThreeErrorMono()
+                .as(mono -> mono);
+
+        StepVerifier.create(test)
+                .expectErrorMessage("Not yet!")
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void oneToManyRetryWhen() {
+        Flux<Integer> test = newThreeErrorMono()
+                .<Flux<Integer>>as(GrpcRetry.OneToMany.retryWhen(Mono::flux, Retry.any().retryMax(4)));
+
+        StepVerifier.create(test)
+                .expectNext(0)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void oneToManyRetryImmediately() {
+        Flux<Integer> test = newThreeErrorMono()
+                .<Flux<Integer>>as(GrpcRetry.OneToMany.retryImmediately(Mono::flux));
+
+        StepVerifier.create(test)
+                .expectNext(0)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void oneToManyRetryAfter() {
+        Flux<Integer> test = newThreeErrorMono()
+                .<Flux<Integer>>as(GrpcRetry.OneToMany.retryAfter(Mono::flux, Duration.ofMillis(10)));
+
+        StepVerifier.create(test)
+                .expectNext(0)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void manyToManyRetryWhen() {
+        Flux<Integer> test = newThreeErrorFlux()
+                .<Integer>compose(GrpcRetry.ManyToMany.retryWhen(Function.identity(), Retry.any().retryMax(4)));
+
+        StepVerifier.create(test)
+                .expectNext(0)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void manyToManyRetryImmediately() {
+        Flux<Integer> test = newThreeErrorFlux()
+                .<Integer>compose(GrpcRetry.ManyToMany.retryImmediately(Function.identity()));
+
+        StepVerifier.create(test)
+                .expectNext(0)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void manyToManyRetryAfter() {
+        Flux<Integer> test = newThreeErrorFlux()
+                .<Integer>compose(GrpcRetry.ManyToMany.retryAfter(Function.identity(), Duration.ofMillis(10)));
+
+        StepVerifier.create(test)
+                .expectNext(0)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void manyToOneRetryWhen() {
+        Mono<Integer> test = newThreeErrorFlux()
+                .<Mono<Integer>>as(GrpcRetry.ManyToOne.retryWhen(Flux::single, Retry.any().retryMax(4)));
+
+        StepVerifier.create(test)
+                .expectNext(0)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void manyToOneRetryImmediately() {
+        Mono<Integer> test = newThreeErrorFlux()
+                .<Mono<Integer>>as(GrpcRetry.ManyToOne.retryImmediately(Flux::single));
+
+        StepVerifier.create(test)
+                .expectNext(0)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void manyToOneRetryAfter() {
+        Mono<Integer> test = newThreeErrorFlux()
+                .<Mono<Integer>>as(GrpcRetry.ManyToOne.retryAfter(Flux::single, Duration.ofMillis(10)));
+
+        StepVerifier.create(test)
+                .expectNext(0)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+    }
+}

--- a/reactor/reactor-grpc-retry/pom.xml
+++ b/reactor/reactor-grpc-retry/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright (c) 2019, Salesforce.com, Inc.
+  ~  All rights reserved.
+  ~  Licensed under the BSD 3-Clause license.
+  ~  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>reactive-grpc</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>reactor-grpc-retry</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>reactive-grpc-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>${reactor.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>${reactor.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.addons</groupId>
+            <artifactId>reactor-extra</artifactId>
+            <version>${reactor.extra.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <configLocation>../../checkstyle.xml</configLocation>
+                    <suppressionsLocation>../../checkstyle_ignore.xml</suppressionsLocation>
+                </configuration>
+            </plugin>
+
+            <!-- Jar and Bundle plugin used for OSGI support -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.2</version>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/reactor/reactor-grpc-retry/src/main/java/com/salesforce/reactorgrpc/retry/GrpcRetry.java
+++ b/reactor/reactor-grpc-retry/src/main/java/com/salesforce/reactorgrpc/retry/GrpcRetry.java
@@ -5,11 +5,12 @@
  *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
-package com.salesforce.reactorgrpc;
+package com.salesforce.reactorgrpc.retry;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 import java.time.Duration;
 import java.util.function.Function;
@@ -31,7 +32,7 @@ public final class GrpcRetry {
         }
 
         /**
-         * Retries a streaming gRPC call, using the same semantics as {@link Flux#retryWhen(Function)}.
+         * Retries a streaming gRPC call, using the same semantics as {@link Flux#retryWhen(Retry)}.
          *
          * For easier use, use the Retry builder from
          * <a href="https://github.com/reactor/reactor-addons/blob/master/reactor-extra/src/main/java/reactor/retry/Retry.java">Reactor Extras</a>.
@@ -41,10 +42,10 @@ public final class GrpcRetry {
          * @param <I> I
          * @param <O> O
          *
-         * @see Flux#retryWhen(Function)
+         * @see Flux#retryWhen(Retry)
          */
         public static <I, O> Function<? super Mono<I>, Flux<O>> retryWhen(final Function<Mono<I>, Flux<O>> operation, final Function<Flux<Throwable>, ? extends Publisher<?>> whenFactory) {
-            return request -> Flux.defer(() -> operation.apply(request)).retryWhen(whenFactory);
+            return request -> Flux.defer(() -> operation.apply(request)).retryWhen(Retry.withThrowable(whenFactory));
         }
 
         /**
@@ -79,7 +80,7 @@ public final class GrpcRetry {
         }
 
         /**
-         * Retries a streaming gRPC call, using the same semantics as {@link Flux#retryWhen(Function)}.
+         * Retries a streaming gRPC call, using the same semantics as {@link Flux#retryWhen(Retry)}.
          *
          * For easier use, use the Retry builder from
          * <a href="https://github.com/reactor/reactor-addons/blob/master/reactor-extra/src/main/java/reactor/retry/Retry.java">Reactor Extras</a>.
@@ -89,10 +90,10 @@ public final class GrpcRetry {
          * @param <I> I
          * @param <O> O
          *
-         * @see Flux#retryWhen(Function)
+         * @see Flux#retryWhen(Retry)
          */
         public static <I, O> Function<? super Flux<I>, ? extends Publisher<O>> retryWhen(final Function<Flux<I>, Flux<O>> operation, final Function<Flux<Throwable>, ? extends Publisher<?>> whenFactory) {
-            return request -> Flux.defer(() -> operation.apply(request)).retryWhen(whenFactory);
+            return request -> Flux.defer(() -> operation.apply(request)).retryWhen(Retry.withThrowable(whenFactory));
         }
 
         /**
@@ -127,7 +128,7 @@ public final class GrpcRetry {
         }
 
         /**
-         * Retries a streaming gRPC call, using the same semantics as {@link Flux#retryWhen(Function)}.
+         * Retries a streaming gRPC call, using the same semantics as {@link Flux#retryWhen(Retry)}.
          *
          * For easier use, use the Retry builder from
          * <a href="https://github.com/reactor/reactor-addons/blob/master/reactor-extra/src/main/java/reactor/retry/Retry.java">Reactor Extras</a>.
@@ -137,10 +138,10 @@ public final class GrpcRetry {
          * @param <I> I
          * @param <O> O
          *
-         * @see Flux#retryWhen(Function)
+         * @see Flux#retryWhen(Retry)
          */
         public static <I, O> Function<? super Flux<I>, Mono<O>> retryWhen(final Function<Flux<I>, Mono<O>> operation, final Function<Flux<Throwable>, ? extends Publisher<?>> whenFactory) {
-            return request -> Mono.defer(() -> operation.apply(request)).retryWhen(whenFactory);
+            return request -> Mono.defer(() -> operation.apply(request)).retryWhen(Retry.withThrowable(whenFactory));
         }
 
         /**

--- a/reactor/reactor-grpc-retry/src/test/java/com/salesforce/reactorgrpc/retry/GrpcRetryTest.java
+++ b/reactor/reactor-grpc-retry/src/test/java/com/salesforce/reactorgrpc/retry/GrpcRetryTest.java
@@ -4,9 +4,8 @@
  *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
-package com.salesforce.reactorgrpc.stub;
+package com.salesforce.reactorgrpc.retry;
 
-import com.salesforce.reactorgrpc.GrpcRetry;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
@@ -108,7 +107,7 @@ public class GrpcRetryTest {
     @Test
     public void manyToManyRetryWhen() {
         Flux<Integer> test = newThreeErrorFlux()
-                .<Integer>compose(GrpcRetry.ManyToMany.retryWhen(Function.identity(), Retry.any().retryMax(4)));
+                .<Integer>transformDeferred(GrpcRetry.ManyToMany.retryWhen(Function.identity(), Retry.any().retryMax(4)));
 
         StepVerifier.create(test)
                 .expectNext(0)
@@ -119,7 +118,7 @@ public class GrpcRetryTest {
     @Test
     public void manyToManyRetryImmediately() {
         Flux<Integer> test = newThreeErrorFlux()
-                .<Integer>compose(GrpcRetry.ManyToMany.retryImmediately(Function.identity()));
+                .<Integer>transformDeferred(GrpcRetry.ManyToMany.retryImmediately(Function.identity()));
 
         StepVerifier.create(test)
                 .expectNext(0)
@@ -130,7 +129,7 @@ public class GrpcRetryTest {
     @Test
     public void manyToManyRetryAfter() {
         Flux<Integer> test = newThreeErrorFlux()
-                .<Integer>compose(GrpcRetry.ManyToMany.retryAfter(Function.identity(), Duration.ofMillis(10)));
+                .<Integer>transformDeferred(GrpcRetry.ManyToMany.retryAfter(Function.identity(), Duration.ofMillis(10)));
 
         StepVerifier.create(test)
                 .expectNext(0)

--- a/reactor/reactor-grpc-stub/pom.xml
+++ b/reactor/reactor-grpc-stub/pom.xml
@@ -37,12 +37,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.projectreactor.addons</groupId>
-            <artifactId>reactor-extra</artifactId>
-            <version>${reactor.extra.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Fixes #233

Reactor 3.3.9 introduced a breaking change to the Flux retry API. I moved retry logic to two different Maven modules. One for pre 3.3.9, and one for 3.3.9 later.

🙄 Who breaks API in a patch release? smh