### PR TITLE
Unwrap incoming `Mono`/`Single` parameters

### DIFF
--- a/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ServerCalls.java
+++ b/reactor/reactor-grpc-stub/src/main/java/com/salesforce/reactorgrpc/stub/ServerCalls.java
@@ -33,11 +33,9 @@ public final class ServerCalls {
      */
     public static <TRequest, TResponse> void oneToOne(
             TRequest request, StreamObserver<TResponse> responseObserver,
-            Function<Mono<TRequest>, Mono<TResponse>> delegate) {
+            Function<TRequest, Mono<TResponse>> delegate) {
         try {
-            Mono<TRequest> rxRequest = Mono.just(request);
-
-            Mono<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(rxRequest));
+            Mono<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(request));
             rxResponse.subscribe(
                 value -> {
                     // Don't try to respond if the server has already canceled the request
@@ -59,11 +57,9 @@ public final class ServerCalls {
      */
     public static <TRequest, TResponse> void oneToMany(
             TRequest request, StreamObserver<TResponse> responseObserver,
-            Function<Mono<TRequest>, Flux<TResponse>> delegate) {
+            Function<TRequest, Flux<TResponse>> delegate) {
         try {
-            Mono<TRequest> rxRequest = Mono.just(request);
-
-            Flux<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(rxRequest));
+            Flux<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(request));
             ReactorSubscriberAndServerProducer<TResponse> server = rxResponse.subscribeWith(new ReactorSubscriberAndServerProducer<>());
             server.subscribe((ServerCallStreamObserver<TResponse>) responseObserver);
         } catch (Throwable throwable) {

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/BackpressureIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/BackpressureIntegrationTest.java
@@ -245,7 +245,7 @@ public class BackpressureIntegrationTest {
         public Flux<NumberProto.Number> twoWayResponsePressure(Flux<NumberProto.Number> request) {
             return Flux.merge(
                     request.then(Mono.empty()),
-                    responsePressure(null)
+                    responsePressure((Empty) null)
             );
         }
     }
@@ -278,7 +278,7 @@ public class BackpressureIntegrationTest {
         @Override
         public Flux<NumberProto.Number> twoWayResponsePressure(Flux<NumberProto.Number> request) {
             request.subscribe();
-            return responsePressure(null);
+            return responsePressure((Empty) null);
         }
     }
 }

--- a/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/EndToEndIntegrationTest.java
+++ b/reactor/reactor-grpc-test/src/test/java/com/salesforce/reactorgrpc/EndToEndIntegrationTest.java
@@ -143,19 +143,16 @@ public class EndToEndIntegrationTest {
     static class TestService extends ReactorGreeterGrpc.GreeterImplBase {
 
         @Override
-        public Mono<HelloResponse> sayHello(Mono<HelloRequest> reactorRequest) {
-            return reactorRequest.hide()
-                                 .map(protoRequest -> greet("Hello", protoRequest));
+        public Mono<HelloResponse> sayHello(HelloRequest protoRequest) {
+            return Mono.fromCallable(() -> greet("Hello", protoRequest));
         }
 
         @Override
-        public Flux<HelloResponse> sayHelloRespStream(Mono<HelloRequest> reactorRequest) {
-            return reactorRequest
-                    .hide()
-                    .flatMapMany(protoRequest -> Flux.just(
+        public Flux<HelloResponse> sayHelloRespStream(HelloRequest protoRequest) {
+            return Flux.just(
                     greet("Hello", protoRequest),
                     greet("Hi", protoRequest),
-                    greet("Greetings", protoRequest)));
+                    greet("Greetings", protoRequest));
         }
 
         @Override

--- a/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
+++ b/reactor/reactor-grpc/src/main/resources/ReactorStub.mustache
@@ -75,6 +75,18 @@ public final class {{className}} {
     public static abstract class {{serviceName}}ImplBase implements io.grpc.BindableService {
 
         {{#methods}}
+        {{^isManyInput}}
+            {{#javaDoc}}
+        {{{javaDoc}}}
+            {{/javaDoc}}
+            {{#deprecated}}
+        @java.lang.Deprecated
+            {{/deprecated}}
+        public {{#isManyOutput}}reactor.core.publisher.Flux{{/isManyOutput}}{{^isManyOutput}}reactor.core.publisher.Mono{{/isManyOutput}}<{{outputType}}> {{methodNameCamelCase}}({{inputType}} request) {
+            return {{methodNameCamelCase}}(reactor.core.publisher.Mono.just(request));
+        }
+        {{/isManyInput}}
+
             {{#javaDoc}}
         {{{javaDoc}}}
             {{/javaDoc}}

--- a/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
+++ b/rx-java/rxgrpc-stub/src/main/java/com/salesforce/rxgrpc/stub/ServerCalls.java
@@ -35,11 +35,9 @@ public final class ServerCalls {
     public static <TRequest, TResponse> void oneToOne(
             final TRequest request,
             final StreamObserver<TResponse> responseObserver,
-            final Function<Single<TRequest>, Single<TResponse>> delegate) {
+            final Function<TRequest, Single<TResponse>> delegate) {
         try {
-            final Single<TRequest> rxRequest = Single.just(request);
-
-            final Single<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(rxRequest));
+            final Single<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(request));
             rxResponse.subscribe(
                     new Consumer<TResponse>() {
                         @Override
@@ -70,11 +68,9 @@ public final class ServerCalls {
     public static <TRequest, TResponse> void oneToMany(
             final TRequest request,
             final StreamObserver<TResponse> responseObserver,
-            final Function<Single<TRequest>, Flowable<TResponse>> delegate) {
+            final Function<TRequest, Flowable<TResponse>> delegate) {
         try {
-            final Single<TRequest> rxRequest = Single.just(request);
-
-            final Flowable<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(rxRequest));
+            final Flowable<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(request));
             final RxSubscriberAndServerProducer<TResponse> serverProducer =
                     rxResponse.subscribeWith(new RxSubscriberAndServerProducer<TResponse>());
             serverProducer.subscribe((ServerCallStreamObserver<TResponse>) responseObserver);

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/BackpressureIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/BackpressureIntegrationTest.java
@@ -69,7 +69,7 @@ public class BackpressureIntegrationTest {
         @Override
         public Flowable<NumberProto.Number> twoWayResponsePressure(Flowable<NumberProto.Number> request) {
             request.subscribe();
-            return responsePressure(null);
+            return responsePressure((Empty) null);
         }
     }
 

--- a/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/EndToEndIntegrationTest.java
+++ b/rx-java/rxgrpc-test/src/test/java/com/salesforce/rxgrpc/EndToEndIntegrationTest.java
@@ -35,16 +35,16 @@ public class EndToEndIntegrationTest {
         RxGreeterGrpc.GreeterImplBase svc = new RxGreeterGrpc.GreeterImplBase() {
 
             @Override
-            public Single<HelloResponse> sayHello(Single<HelloRequest> rxRequest) {
-                return rxRequest.map(protoRequest -> greet("Hello", protoRequest));
+            public Single<HelloResponse> sayHello(HelloRequest protoRequest) {
+                return Single.fromCallable(() -> greet("Hello", protoRequest));
             }
 
             @Override
-            public Flowable<HelloResponse> sayHelloRespStream(Single<HelloRequest> rxRequest) {
-                return rxRequest.flatMapPublisher(protoRequest -> Flowable.just(
+            public Flowable<HelloResponse> sayHelloRespStream(HelloRequest protoRequest) {
+                return Flowable.just(
                         greet("Hello", protoRequest),
                         greet("Hi", protoRequest),
-                        greet("Greetings", protoRequest)));
+                        greet("Greetings", protoRequest));
             }
 
             @Override

--- a/rx-java/rxgrpc/src/main/resources/RxStub.mustache
+++ b/rx-java/rxgrpc/src/main/resources/RxStub.mustache
@@ -97,6 +97,18 @@ public final class {{className}} {
     public static abstract class {{serviceName}}ImplBase implements io.grpc.BindableService {
 
         {{#methods}}
+        {{^isManyInput}}
+            {{#javaDoc}}
+                {{{javaDoc}}}
+            {{/javaDoc}}
+            {{#deprecated}}
+                @java.lang.Deprecated
+            {{/deprecated}}
+        public {{#isManyOutput}}io.reactivex.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.Single{{/isManyOutput}}<{{outputType}}> {{methodNameCamelCase}}({{inputType}} request) {
+            return {{methodNameCamelCase}}(io.reactivex.Single.just(request));
+        }
+        {{/isManyInput}}
+
             {{#javaDoc}}
         {{{javaDoc}}}
             {{/javaDoc}}
@@ -154,9 +166,9 @@ public final class {{className}} {
                 case METHODID_{{methodNameUpperUnderscore}}:
                     com.salesforce.rxgrpc.stub.ServerCalls.{{reactiveCallsMethodName}}(({{inputType}}) request,
                             (io.grpc.stub.StreamObserver<{{outputType}}>) responseObserver,
-                            new com.salesforce.reactivegrpc.common.Function<{{#isManyInput}}io.reactivex.Flowable{{/isManyInput}}{{^isManyInput}}io.reactivex.Single{{/isManyInput}}<{{inputType}}>, {{#isManyOutput}}io.reactivex.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.Single{{/isManyOutput}}<{{outputType}}>>() {
+                            new com.salesforce.reactivegrpc.common.Function<{{#isManyInput}}io.reactivex.Flowable<{{inputType}}>{{/isManyInput}}{{^isManyInput}}{{inputType}}{{/isManyInput}}, {{#isManyOutput}}io.reactivex.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.Single{{/isManyOutput}}<{{outputType}}>>() {
                                 @java.lang.Override
-                                public {{#isManyOutput}}io.reactivex.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.Single{{/isManyOutput}}<{{outputType}}> apply({{#isManyInput}}io.reactivex.Flowable{{/isManyInput}}{{^isManyInput}}io.reactivex.Single{{/isManyInput}}<{{inputType}}> single) {
+                                public {{#isManyOutput}}io.reactivex.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.Single{{/isManyOutput}}<{{outputType}}> apply({{#isManyInput}}io.reactivex.Flowable<{{inputType}}>{{/isManyInput}}{{^isManyInput}}{{inputType}}{{/isManyInput}} single) {
                                     return serviceImpl.{{methodNameCamelCase}}(single);
                                 }
                             });

--- a/rx3-java/rx3grpc-stub/src/main/java/com/salesforce/rx3grpc/stub/ServerCalls.java
+++ b/rx3-java/rx3grpc-stub/src/main/java/com/salesforce/rx3grpc/stub/ServerCalls.java
@@ -36,11 +36,9 @@ public final class ServerCalls {
     public static <TRequest, TResponse> void oneToOne(
             final TRequest request,
             final StreamObserver<TResponse> responseObserver,
-            final Function<Single<TRequest>, Single<TResponse>> delegate) {
+            final Function<TRequest, Single<TResponse>> delegate) {
         try {
-            final Single<TRequest> rxRequest = Single.just(request);
-
-            final Single<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(rxRequest));
+            final Single<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(request));
             rxResponse.subscribe(
                     new Consumer<TResponse>() {
                         @Override
@@ -71,11 +69,9 @@ public final class ServerCalls {
     public static <TRequest, TResponse> void oneToMany(
             final TRequest request,
             final StreamObserver<TResponse> responseObserver,
-            final Function<Single<TRequest>, Flowable<TResponse>> delegate) {
+            final Function<TRequest, Flowable<TResponse>> delegate) {
         try {
-            final Single<TRequest> rxRequest = Single.just(request);
-
-            final Flowable<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(rxRequest));
+            final Flowable<TResponse> rxResponse = Preconditions.checkNotNull(delegate.apply(request));
             final RxSubscriberAndServerProducer<TResponse> serverProducer =
                     rxResponse.subscribeWith(new RxSubscriberAndServerProducer<TResponse>());
             serverProducer.subscribe((ServerCallStreamObserver<TResponse>) responseObserver);

--- a/rx3-java/rx3grpc-test/src/test/java/com/salesforce/rx3grpc/BackpressureIntegrationTest.java
+++ b/rx3-java/rx3grpc-test/src/test/java/com/salesforce/rx3grpc/BackpressureIntegrationTest.java
@@ -73,7 +73,7 @@ public class BackpressureIntegrationTest {
         @Override
         public Flowable<NumberProto.Number> twoWayResponsePressure(Flowable<NumberProto.Number> request) {
             request.subscribe();
-            return responsePressure(null);
+            return responsePressure((Empty) null);
         }
     }
 

--- a/rx3-java/rx3grpc-test/src/test/java/com/salesforce/rx3grpc/EndToEndIntegrationTest.java
+++ b/rx3-java/rx3grpc-test/src/test/java/com/salesforce/rx3grpc/EndToEndIntegrationTest.java
@@ -36,16 +36,16 @@ public class EndToEndIntegrationTest {
         Rx3GreeterGrpc.GreeterImplBase svc = new Rx3GreeterGrpc.GreeterImplBase() {
 
             @Override
-            public Single<HelloResponse> sayHello(Single<HelloRequest> rxRequest) {
-                return rxRequest.map(protoRequest -> greet("Hello", protoRequest));
+            public Single<HelloResponse> sayHello(HelloRequest protoRequest) {
+                return Single.fromCallable(() -> greet("Hello", protoRequest));
             }
 
             @Override
-            public Flowable<HelloResponse> sayHelloRespStream(Single<HelloRequest> rxRequest) {
-                return rxRequest.flatMapPublisher(protoRequest -> Flowable.just(
+            public Flowable<HelloResponse> sayHelloRespStream(HelloRequest protoRequest) {
+                return Flowable.just(
                         greet("Hello", protoRequest),
                         greet("Hi", protoRequest),
-                        greet("Greetings", protoRequest)));
+                        greet("Greetings", protoRequest));
             }
 
             @Override

--- a/rx3-java/rx3grpc/src/main/resources/Rx3Stub.mustache
+++ b/rx3-java/rx3grpc/src/main/resources/Rx3Stub.mustache
@@ -97,6 +97,18 @@ public final class {{className}} {
     public static abstract class {{serviceName}}ImplBase implements io.grpc.BindableService {
 
         {{#methods}}
+        {{^isManyInput}}
+            {{#javaDoc}}
+        {{{javaDoc}}}
+            {{/javaDoc}}
+            {{#deprecated}}
+        @java.lang.Deprecated
+            {{/deprecated}}
+        public {{#isManyOutput}}io.reactivex.rxjava3.core.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.rxjava3.core.Single{{/isManyOutput}}<{{outputType}}> {{methodNameCamelCase}}({{inputType}} request) {
+            return {{methodNameCamelCase}}(io.reactivex.rxjava3.core.Single.just(request));
+        }
+        {{/isManyInput}}
+
             {{#javaDoc}}
         {{{javaDoc}}}
             {{/javaDoc}}
@@ -154,9 +166,9 @@ public final class {{className}} {
                 case METHODID_{{methodNameUpperUnderscore}}:
                     com.salesforce.rx3grpc.stub.ServerCalls.{{reactiveCallsMethodName}}(({{inputType}}) request,
                             (io.grpc.stub.StreamObserver<{{outputType}}>) responseObserver,
-                            new com.salesforce.reactivegrpc.common.Function<{{#isManyInput}}io.reactivex.rxjava3.core.Flowable{{/isManyInput}}{{^isManyInput}}io.reactivex.rxjava3.core.Single{{/isManyInput}}<{{inputType}}>, {{#isManyOutput}}io.reactivex.rxjava3.core.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.rxjava3.core.Single{{/isManyOutput}}<{{outputType}}>>() {
+                            new com.salesforce.reactivegrpc.common.Function<{{#isManyInput}}io.reactivex.rxjava3.core.Flowable<{{inputType}}>{{/isManyInput}}{{^isManyInput}}{{inputType}}{{/isManyInput}}, {{#isManyOutput}}io.reactivex.rxjava3.core.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.rxjava3.core.Single{{/isManyOutput}}<{{outputType}}>>() {
                                 @java.lang.Override
-                                public {{#isManyOutput}}io.reactivex.rxjava3.core.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.rxjava3.core.Single{{/isManyOutput}}<{{outputType}}> apply({{#isManyInput}}io.reactivex.rxjava3.core.Flowable{{/isManyInput}}{{^isManyInput}}io.reactivex.rxjava3.core.Single{{/isManyInput}}<{{inputType}}> single) {
+                                public {{#isManyOutput}}io.reactivex.rxjava3.core.Flowable{{/isManyOutput}}{{^isManyOutput}}io.reactivex.rxjava3.core.Single{{/isManyOutput}}<{{outputType}}> apply({{#isManyInput}}io.reactivex.rxjava3.core.Flowable<{{inputType}}>{{/isManyInput}}{{^isManyInput}}{{inputType}}{{/isManyInput}} single) {
                                     return serviceImpl.{{methodNameCamelCase}}(single);
                                 }
                             });


### PR DESCRIPTION
It is uncommon to have methods accept `Mono` as a parameter. The fact that `ServerCalls` did `Mono.just` is also a good indicator. This change makes single-input methods look like `Mono<Response> foo(Request request)` instead of `Mono<Response> foo(Mono<Request> request)`.

It is backward compatible and will delegate to the `Mono` one (unless overridden, of course).

Closes #78 and #295